### PR TITLE
Special-case trailing slash in path prefix.

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
@@ -113,7 +113,8 @@ public abstract class AbstractUpload
    * build's outcome
    * @param pathPrefix Path prefix to strip from uploaded files when determining
    * the filename in GCS. Null indicates no stripping. Filenames that do not
-   * start with this prefix will not be modified.
+   * start with this prefix will not be modified. Trailing slash is
+   * automatically added if it is missing.
    */
   public AbstractUpload(String bucket, boolean sharedPublicly,
       boolean forFailedJobs, @Nullable String pathPrefix,
@@ -126,6 +127,9 @@ public abstract class AbstractUpload
     this.bucketNameWithVars = checkNotNull(bucket);
     this.sharedPublicly = sharedPublicly;
     this.forFailedJobs = forFailedJobs;
+    if (pathPrefix != null && !pathPrefix.endsWith("/")) {
+      pathPrefix += "/";
+    }
     this.pathPrefix = pathPrefix;
   }
 

--- a/src/main/resources/com/google/jenkins/plugins/storage/AbstractUpload/help-pathPrefix.html
+++ b/src/main/resources/com/google/jenkins/plugins/storage/AbstractUpload/help-pathPrefix.html
@@ -1,5 +1,5 @@
 <div>
   <p>
-    The specified prefix will be stripped from all uploaded filenames. Filenames that do not start with this prefix will not be modified.
+    The specified prefix will be stripped from all uploaded filenames. Filenames that do not start with this prefix will not be modified. If this prefix does not have a trailing slash, it will be added automatically.
   </p>
 </div>


### PR DESCRIPTION
Add a special case to explicitly add a trailing slash when the path prefix does not have one. E.g. "subdir/file1", with a path prefix of "subdir", will result in an uploaded file of "file1", not "/file1".