### PR TITLE
Content disposition on file that can be view in the browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+target

--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@ Jenkins Google Storage Credentials Plugin
 
 This plugin provides the “Google Cloud Storage Uploader” post-build step for publishing build artifacts to Google Cloud Storage.
 
-Why did I clone this repo?
---------------
-I wanted to remove Content-Disposition header being automaticly added to the upload since html files where downloaded instead of viewed.
+[![Build Status](https://jenkins.ci.cloudbees.com/buildStatus/icon?job=plugins/google-storage-plugin)](https://jenkins.ci.cloudbees.com/job/plugins/job/google-storage-plugin/)
 
 Read more: [http://wiki.jenkins-ci.org/display/JENKINS/Google+Cloud+Storage+Plugin](http://wiki.jenkins-ci.org/display/JENKINS/Google+Cloud+Storage+Plugin)
 

--- a/src/main/java/com/google/jenkins/plugins/storage/HttpHeaders.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/HttpHeaders.java
@@ -91,8 +91,8 @@ public class HttpHeaders {
           "html","htm","jpeg",
           "jpg","mp3","mpeg",
           "mpg","mov","qt",
-          "pdf","png",
-          "tiff","txt","wav"};
+          "pdf","png","xml",
+          "tiff","txt","wav","log"};
   private HttpHeaders() {
 
   }

--- a/src/main/java/com/google/jenkins/plugins/storage/HttpHeaders.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/HttpHeaders.java
@@ -25,12 +25,17 @@ public class HttpHeaders {
   /**
    * Returns an RFC 6266 Content-Disposition header for the given filename.
    */
+
+
   public static String getContentDisposition(String filename) {
-    return "";
-//    return String.format(
-//        "attachment; filename=%s; filename*=%s",
-//        getRfc2616QuotedString(filename),
-//        getRfc5987ExtValue(filename));
+    for(String ex: viewableExtentions)
+       if(filename.toLowerCase().endsWith(ex))
+          return "";
+
+    return String.format(
+        "attachment; filename=%s; filename*=%s",
+        getRfc2616QuotedString(filename),
+        getRfc5987ExtValue(filename));
   }
 
   /**
@@ -81,6 +86,14 @@ public class HttpHeaders {
   }
 
   private static final String RFC_5987_ATTR_CHARS = "!#$&+-.^_`|~";
+  private static String[] viewableExtentions =
+          {"avi","css","gif",
+          "html","htm","jpeg",
+          "jpg","mp3","mpeg",
+          "mpg","mov","qt",
+          "pdf","png",
+          "tiff","txt","wav"};
+  private HttpHeaders() {
 
-  private HttpHeaders() {}
+  }
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/HttpHeaders.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/HttpHeaders.java
@@ -27,10 +27,10 @@ public class HttpHeaders {
    */
   public static String getContentDisposition(String filename) {
     return "";
-    return String.format(
-        "attachment; filename=%s; filename*=%s",
-        getRfc2616QuotedString(filename),
-        getRfc5987ExtValue(filename));
+//    return String.format(
+//        "attachment; filename=%s; filename*=%s",
+//        getRfc2616QuotedString(filename),
+//        getRfc5987ExtValue(filename));
   }
 
   /**

--- a/src/main/java/com/google/jenkins/plugins/storage/HttpHeaders.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/HttpHeaders.java
@@ -20,18 +20,22 @@ import com.google.common.base.Charsets;
 /**
  * Utility class for building HTTP header values.
  */
-public class HttpHeaders {
+public final class HttpHeaders {
 
   /**
    * Returns an RFC 6266 Content-Disposition header for the given filename.
+   * @return
+   * the content disposition
+   * @param filename
+   * the file name
    */
 
-
-  public static String getContentDisposition(String filename) {
-    for(String ex: viewableExtentions)
-       if(filename.toLowerCase().endsWith(ex))
-          return "";
-
+  public static String getContentDisposition(final String filename) {
+    for (String ex: viewableExtentions) {
+        if (filename.toLowerCase().endsWith(ex)) {
+            return "";
+        }
+    }
     return String.format(
         "attachment; filename=%s; filename*=%s",
         getRfc2616QuotedString(filename),
@@ -39,12 +43,16 @@ public class HttpHeaders {
   }
 
   /**
+   * @return
    * Returns an RFC 2616 quoted-string encoding of the given text. Code points
    * &lt;= U+255 will be encoded, others will be zapped to underscore.
+   *
+   * @param text
+   * the text
    */
-  private static String getRfc2616QuotedString(String text) {
+  private static String getRfc2616QuotedString(final String text) {
     StringBuilder builder = new StringBuilder("\"");
-    for (int i = 0; i < text.length(); ) {
+    for (int i = 0; i < text.length();) {
       int codePoint = text.codePointAt(i);
       i += Character.charCount(codePoint);
       if (codePoint == '"') {
@@ -62,12 +70,15 @@ public class HttpHeaders {
   }
 
   /**
+   * @return
    * Returns an RFC 5987 ext-value encoding of the given text, with charset
    * UTF-8 and no language tag.
+   * @param text
+   * the text
    */
-  private static String getRfc5987ExtValue(String text) {
+  private static String getRfc5987ExtValue(final String text) {
     StringBuilder builder = new StringBuilder("UTF-8''");
-    for (int i = 0; i < text.length(); ) {
+    for (int i = 0; i < text.length();) {
       int codePoint = text.codePointAt(i);
       int len = Character.charCount(codePoint);
       if ((codePoint >= '0' && codePoint <= '9')
@@ -87,12 +98,12 @@ public class HttpHeaders {
 
   private static final String RFC_5987_ATTR_CHARS = "!#$&+-.^_`|~";
   private static String[] viewableExtentions =
-          {"avi","css","gif",
-          "html","htm","jpeg",
-          "jpg","mp3","mpeg",
-          "mpg","mov","qt",
-          "pdf","png","xml",
-          "tiff","txt","wav","log"};
+          {"avi", "css", "gif",
+          "html", "htm", "jpeg",
+          "jpg", "mp3", "mpeg",
+          "mpg", "mov", "qt",
+          "pdf", "png", "xml",
+          "tiff", "txt", "wav", "log"};
   private HttpHeaders() {
 
   }

--- a/src/main/java/com/google/jenkins/plugins/storage/HttpHeaders.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/HttpHeaders.java
@@ -26,6 +26,7 @@ public class HttpHeaders {
    * Returns an RFC 6266 Content-Disposition header for the given filename.
    */
   public static String getContentDisposition(String filename) {
+    return "";
     return String.format(
         "attachment; filename=%s; filename*=%s",
         getRfc2616QuotedString(filename),

--- a/src/test/java/com/google/jenkins/plugins/storage/HttpHeadersTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/HttpHeadersTest.java
@@ -22,8 +22,9 @@ import org.junit.Test;
 /**
  * Tests for {@link HttpHeaders}.
  */
-public class HttpHeadersTest {
 
+public class HttpHeadersTest {
+    /*
   @Test
   public void testGetContentDisposition_ascii() {
     assertEquals(
@@ -73,4 +74,5 @@ public class HttpHeadersTest {
             + "%3C%3E%2C%2F%3F",
         HttpHeaders.getContentDisposition("@%*()=[]{}\\:;\"'<>,/?"));
   }
+  */
 }

--- a/src/test/java/com/google/jenkins/plugins/storage/HttpHeadersTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/HttpHeadersTest.java
@@ -80,8 +80,8 @@ public class HttpHeadersTest {
                         "Html","htm","jpeg",
                         "jpg","MP3","mpeg",
                         "mpg","mov","qt",
-                        "pdf","png",
-                        "tiff","TXT","wav"};
+                        "pdf","png","XML",
+                        "tiff","TXT","wav","log"};
         for(String ex: viewableExtentions)
             assertEquals("",HttpHeaders.getContentDisposition("someFile." + ex));
     }

--- a/src/test/java/com/google/jenkins/plugins/storage/HttpHeadersTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/HttpHeadersTest.java
@@ -84,7 +84,8 @@ public class HttpHeadersTest {
                         "pdf", "png", "XML",
                         "tiff", "TXT", "wav", "log"};
         for (String ex: viewableExtentions) {
-            assertEquals("",HttpHeaders.getContentDisposition("someFile." + ex));
+            assertEquals("",
+                    HttpHeaders.getContentDisposition("someFile." + ex));
         }
     }
 }

--- a/src/test/java/com/google/jenkins/plugins/storage/HttpHeadersTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/HttpHeadersTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
  */
 
 public class HttpHeadersTest {
-    /*
   @Test
   public void testGetContentDisposition_ascii() {
     assertEquals(
@@ -32,17 +31,17 @@ public class HttpHeadersTest {
         HttpHeaders.getContentDisposition("myapp.war"));
 
     assertEquals(
-        "attachment; filename=\"contains space.txt\"; "
-            + "filename*=UTF-8''contains%20space.txt",
-        HttpHeaders.getContentDisposition("contains space.txt"));
+        "attachment; filename=\"contains space.txt2\"; "
+            + "filename*=UTF-8''contains%20space.txt2",
+        HttpHeaders.getContentDisposition("contains space.txt2"));
   }
 
   @Test
   public void testGetContentDisposition_unicodeBmp() {
     assertEquals(
-        "attachment; filename=\"snowman _.txt\"; "
-            + "filename*=UTF-8''snowman%20%E2%98%83.txt",
-        HttpHeaders.getContentDisposition("snowman ☃.txt"));
+        "attachment; filename=\"snowman _.txt2\"; "
+            + "filename*=UTF-8''snowman%20%E2%98%83.txt2",
+        HttpHeaders.getContentDisposition("snowman ☃.txt2"));
   }
 
   @Test
@@ -74,5 +73,16 @@ public class HttpHeadersTest {
             + "%3C%3E%2C%2F%3F",
         HttpHeaders.getContentDisposition("@%*()=[]{}\\:;\"'<>,/?"));
   }
-  */
+    @Test
+    public void testGetContentDisposition_emptyForViewableFiles(){
+        String[] viewableExtentions =
+                {"avi","css","gif",
+                        "Html","htm","jpeg",
+                        "jpg","MP3","mpeg",
+                        "mpg","mov","qt",
+                        "pdf","png",
+                        "tiff","TXT","wav"};
+        for(String ex: viewableExtentions)
+            assertEquals("",HttpHeaders.getContentDisposition("someFile." + ex));
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/storage/HttpHeadersTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/HttpHeadersTest.java
@@ -73,16 +73,18 @@ public class HttpHeadersTest {
             + "%3C%3E%2C%2F%3F",
         HttpHeaders.getContentDisposition("@%*()=[]{}\\:;\"'<>,/?"));
   }
+
     @Test
-    public void testGetContentDisposition_emptyForViewableFiles(){
+    public void testGetContentDisposition_emptyForViewableFiles() {
         String[] viewableExtentions =
-                {"avi","css","gif",
-                        "Html","htm","jpeg",
-                        "jpg","MP3","mpeg",
-                        "mpg","mov","qt",
-                        "pdf","png","XML",
-                        "tiff","TXT","wav","log"};
-        for(String ex: viewableExtentions)
+                {"avi", "css", "gif",
+                        "Html", "htm", "jpeg",
+                        "jpg", "MP3", "mpeg",
+                        "mpg", "mov", "qt",
+                        "pdf", "png", "XML",
+                        "tiff", "TXT", "wav", "log"};
+        for (String ex: viewableExtentions) {
             assertEquals("",HttpHeaders.getContentDisposition("someFile." + ex));
+        }
     }
 }


### PR DESCRIPTION
When a file has an extension that is viewable by the browser, I set the content disposition to an empty string so that files like html don't get downloaded.