### PR TITLE
Add option allowing uploaded objects to be shown inline in browsers

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractBucketLifecycleManager.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractBucketLifecycleManager.java
@@ -69,8 +69,8 @@ public abstract class AbstractBucketLifecycleManager extends AbstractUpload {
    */
   public AbstractBucketLifecycleManager(String bucket,
       @Nullable UploadModule module) {
-    super(bucket, false /*sharedPublicly*/,
-        false /*forFailedJobs*/, null /*pathPrefix */, module);
+    super(bucket, false /*sharedPublicly*/, false /*forFailedJobs*/,
+        false /*showInline*/, null /*pathPrefix */, module);
   }
 
   /**

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
@@ -117,13 +117,16 @@ public abstract class AbstractUpload
    * @param sharedPublicly Whether to publicly share the objects being uploaded
    * @param forFailedJobs Whether to perform the upload regardless of the
    * build's outcome
+   * @param showInline Whether to indicate in metadata that the file should be
+   * viewable inline in web browsers, rather than requiring it to be downloaded
+   * first.
    * @param pathPrefix Path prefix to strip from uploaded files when determining
    * the filename in GCS. Null indicates no stripping. Filenames that do not
    * start with this prefix will not be modified. Trailing slash is
    * automatically added if it is missing.
    */
   public AbstractUpload(String bucket, boolean sharedPublicly,
-      boolean forFailedJobs, @Nullable String pathPrefix,
+      boolean forFailedJobs, boolean showInline, @Nullable String pathPrefix,
       @Nullable UploadModule module) {
     if (module != null) {
       this.module = module;
@@ -133,6 +136,7 @@ public abstract class AbstractUpload
     this.bucketNameWithVars = checkNotNull(bucket);
     this.sharedPublicly = sharedPublicly;
     this.forFailedJobs = forFailedJobs;
+    this.showInline = showInline;
     if (pathPrefix != null && !pathPrefix.endsWith("/")) {
       pathPrefix += "/";
     }
@@ -286,6 +290,15 @@ public abstract class AbstractUpload
   private final boolean forFailedJobs;
 
   /**
+   * Whether to indicate in metadata that the file should be viewable inline
+   * in web browsers, rather than requiring it to be downloaded first.
+   */
+  public boolean isShowInline() {
+    return showInline;
+  }
+  private final boolean showInline;
+
+  /**
    * The path prefix that will be stripped from uploaded files. May be null
    * if no path prefix needs to be stripped.
    */
@@ -417,7 +430,8 @@ public abstract class AbstractUpload
           StorageObject object = new StorageObject()
               .setName(finalName)
               .setContentDisposition(
-                  HttpHeaders.getContentDisposition(include.getName()))
+                  HttpHeaders.getContentDisposition(
+                    include.getName(), isShowInline()))
               .setContentType(
                   detectMIMEType(include.getName()))
               .setSize(BigInteger.valueOf(include.length()));

--- a/src/main/java/com/google/jenkins/plugins/storage/ClassicUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/ClassicUpload.java
@@ -46,14 +46,14 @@ public class ClassicUpload extends AbstractUpload {
    */
   @DataBoundConstructor
   public ClassicUpload(String bucket, boolean sharedPublicly,
-      boolean forFailedJobs, boolean stripPathPrefix,
+      boolean forFailedJobs, boolean showInline, boolean stripPathPrefix,
       @Nullable String pathPrefix, @Nullable UploadModule module,
       String pattern,
       // Legacy arguments for backwards compatibility
       @Deprecated @Nullable String bucketNameWithVars,
       @Deprecated @Nullable String sourceGlobWithVars) {
     super(Objects.firstNonNull(bucket, bucketNameWithVars), sharedPublicly,
-        forFailedJobs, stripPathPrefix ? pathPrefix : null, module);
+        forFailedJobs, showInline, stripPathPrefix ? pathPrefix : null, module);
     this.sourceGlobWithVars =
         Objects.firstNonNull(pattern, sourceGlobWithVars);
   }

--- a/src/main/java/com/google/jenkins/plugins/storage/GoogleCloudStorageUploader.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/GoogleCloudStorageUploader.java
@@ -170,6 +170,7 @@ public class GoogleCloudStorageUploader extends Recorder {
           new StdoutUpload(GCS_SCHEME,
               false /* public? */, true /* for failed? */,
               false /* strip path prefix? */,
+              false /* show inline? */,
               null /* path prefix */,
               null /* module */, "build-log.txt" /* log name */,
               null /* legacy arg: bucketNameWithVars */));

--- a/src/main/java/com/google/jenkins/plugins/storage/HttpHeaders.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/HttpHeaders.java
@@ -25,9 +25,11 @@ public class HttpHeaders {
   /**
    * Returns an RFC 6266 Content-Disposition header for the given filename.
    */
-  public static String getContentDisposition(String filename) {
+  public static String getContentDisposition(String filename,
+      boolean showInline) {
     return String.format(
-        "attachment; filename=%s; filename*=%s",
+        "%s; filename=%s; filename*=%s",
+        showInline ? "inline" : "attachment",
         getRfc2616QuotedString(filename),
         getRfc5987ExtValue(filename));
   }

--- a/src/main/java/com/google/jenkins/plugins/storage/StdoutUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/StdoutUpload.java
@@ -54,13 +54,13 @@ public class StdoutUpload extends AbstractUpload {
    */
   @DataBoundConstructor
   public StdoutUpload(@Nullable String bucket, boolean sharedPublicly,
-      boolean forFailedJobs, boolean stripPathPrefix,
+      boolean forFailedJobs, boolean showInline, boolean stripPathPrefix,
       @Nullable String pathPrefix,
       @Nullable UploadModule module, String logName,
       // Legacy arguments for backwards compatibility
       @Deprecated @Nullable String bucketNameWithVars) {
     super(Objects.firstNonNull(bucket, bucketNameWithVars), sharedPublicly,
-        forFailedJobs, stripPathPrefix ? pathPrefix : null, module);
+        forFailedJobs, showInline, stripPathPrefix ? pathPrefix : null, module);
     this.logName = checkNotNull(logName);
   }
 

--- a/src/main/resources/com/google/jenkins/plugins/storage/AbstractUpload/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/storage/AbstractUpload/config.jelly
@@ -38,6 +38,12 @@
     <f:checkbox />
   </f:entry>
 
+  <!-- Allow the user to indicate that these files should be viewable
+  inline in the browser -->
+  <f:entry title="${%Show inline in browser?}" field="showInline">
+    <f:checkbox />
+  </f:entry>
+
   <!-- Allow the user to indicate that they want to strip path prefixes
   from uploaded file names -->
   <f:optionalBlock title="${%Strip path prefix?}" name="stripPathPrefix"
@@ -46,6 +52,7 @@
       <f:textbox default="" />
     </f:entry>
   </f:optionalBlock>
+
 
   <!-- Allow implementations to hook in an advanced form section -->
   <st:include class="${descriptor.clazz}" page="advanced.jelly" optional="true" />

--- a/src/test/java/com/google/jenkins/plugins/storage/AbstractUploadTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/AbstractUploadTest.java
@@ -162,9 +162,9 @@ public class AbstractUploadTest {
 
   private static class FakeUpload extends AbstractUpload {
     public FakeUpload(String bucket, boolean isPublic, boolean forFailed,
-        @Nullable String pathPrefix, MockUploadModule module, String details,
-        @Nullable UploadSpec uploads) {
-      super(bucket, isPublic, forFailed, pathPrefix, module);
+        boolean showInline, @Nullable String pathPrefix,
+        MockUploadModule module, String details, @Nullable UploadSpec uploads) {
+      super(bucket, isPublic, forFailed, showInline, pathPrefix, module);
       this.details = details;
       this.uploads = uploads;
     }
@@ -255,9 +255,10 @@ public class AbstractUploadTest {
   public void testGetters() {
     final boolean sharedPublicly = false;
     final boolean forFailedJobs = true;
+    final boolean showInline = true;
     final String pathPrefix = null;
     FakeUpload underTest = new FakeUpload(BUCKET_URI,
-        sharedPublicly, forFailedJobs, pathPrefix,
+        sharedPublicly, forFailedJobs, showInline, pathPrefix,
         new MockUploadModule(executor),
         FAKE_DETAILS,
         null /* uploads */);
@@ -265,6 +266,7 @@ public class AbstractUploadTest {
     assertEquals(BUCKET_URI, underTest.getBucket());
     assertEquals(sharedPublicly, underTest.isSharedPublicly());
     assertEquals(forFailedJobs, underTest.isForFailedJobs());
+    assertEquals(showInline, underTest.isShowInline());
   }
 
   @Test(expected = NullPointerException.class)
@@ -273,6 +275,7 @@ public class AbstractUploadTest {
     new FakeUpload(null /* TESTING NULL BUCKET*/,
         false /* sharedPublicly */,
         true /* forFailedJobs */,
+        false /* showInline */,
         null /* pathPrefix */,
         new MockUploadModule(executor),
         FAKE_DETAILS,
@@ -285,6 +288,7 @@ public class AbstractUploadTest {
     new FakeUpload(BUCKET_URI,
         false /* sharedPublicly */,
         true /* forFailedJobs */,
+        false /* showInline */,
         null /* pathPrefix */,
         null /* TESTING NULL MODULE*/,
         FAKE_DETAILS,
@@ -295,6 +299,7 @@ public class AbstractUploadTest {
   public void testKeepPathPrefix() throws Exception {
     final boolean sharedPublicly = false;
     final boolean forFailedJobs = true;
+    final boolean showInline = false;
     final String pathPrefix = null;
 
     final AbstractUpload.UploadSpec uploads =
@@ -302,7 +307,7 @@ public class AbstractUploadTest {
             ImmutableList.of(workspaceSubdirFile));
 
     FakeUpload underTest = new FakeUpload(BUCKET_URI,
-        sharedPublicly, forFailedJobs, pathPrefix,
+        sharedPublicly, forFailedJobs, showInline, pathPrefix,
         new MockUploadModule(executor),
         FAKE_DETAILS,
         uploads);
@@ -320,6 +325,7 @@ public class AbstractUploadTest {
   public void testStripPathPrefixWithCorrectPrefix() throws Exception {
     final boolean sharedPublicly = false;
     final boolean forFailedJobs = true;
+    final boolean showInline = false;
     final String pathPrefix = STRIP_PREFIX;
 
     final AbstractUpload.UploadSpec uploads =
@@ -327,7 +333,7 @@ public class AbstractUploadTest {
             ImmutableList.of(workspaceSubdirFile));
 
     FakeUpload underTest = new FakeUpload(BUCKET_URI,
-        sharedPublicly, forFailedJobs, pathPrefix,
+        sharedPublicly, forFailedJobs, showInline, pathPrefix,
         new MockUploadModule(executor),
         FAKE_DETAILS,
         uploads);
@@ -351,6 +357,7 @@ public class AbstractUploadTest {
   public void testStripPathPrefixWithWrongPrefix() throws Exception {
     final boolean sharedPublicly = false;
     final boolean forFailedJobs = true;
+    final boolean showInline = false;
     final String pathPrefix = WRONG_PREFIX;
 
     final AbstractUpload.UploadSpec uploads =
@@ -358,7 +365,7 @@ public class AbstractUploadTest {
             ImmutableList.of(workspaceSubdirFile));
 
     FakeUpload underTest = new FakeUpload(BUCKET_URI,
-        sharedPublicly, forFailedJobs, pathPrefix,
+        sharedPublicly, forFailedJobs, showInline, pathPrefix,
         new MockUploadModule(executor),
         FAKE_DETAILS,
         uploads);
@@ -376,6 +383,7 @@ public class AbstractUploadTest {
   public void testStripPathPrefixNoTrailingSlash() throws Exception {
     final boolean sharedPublicly = false;
     final boolean forFailedJobs = true;
+    final boolean showInline = false;
     final String pathPrefix = STRIP_PREFIX_NO_SLASH;
 
     final AbstractUpload.UploadSpec uploads =
@@ -383,7 +391,7 @@ public class AbstractUploadTest {
             ImmutableList.of(workspaceSubdirFile));
 
     FakeUpload underTest = new FakeUpload(BUCKET_URI,
-        sharedPublicly, forFailedJobs, pathPrefix,
+        sharedPublicly, forFailedJobs, showInline, pathPrefix,
         new MockUploadModule(executor),
         FAKE_DETAILS,
         uploads);
@@ -401,6 +409,7 @@ public class AbstractUploadTest {
   public void testStripPathPrefixWithNonDirectoryPrefix() throws Exception {
     final boolean sharedPublicly = false;
     final boolean forFailedJobs = true;
+    final boolean showInline = false;
     // This string is a prefix of the input file string,
     // but is not at a directory boundary;  it should not be stripped.
     final String pathPrefix = STRIP_PREFIX_MALFORMED;
@@ -410,7 +419,7 @@ public class AbstractUploadTest {
             ImmutableList.of(workspaceSubdirFile));
 
     FakeUpload underTest = new FakeUpload(BUCKET_URI,
-        sharedPublicly, forFailedJobs, pathPrefix,
+        sharedPublicly, forFailedJobs, showInline, pathPrefix,
         new MockUploadModule(executor),
         FAKE_DETAILS,
         uploads);
@@ -428,6 +437,7 @@ public class AbstractUploadTest {
   public void testOnePartPrefix() throws Exception {
     final boolean sharedPublicly = false;
     final boolean forFailedJobs = true;
+    final boolean showInline = false;
     final String pathPrefix = null;
 
     final AbstractUpload.UploadSpec uploads =
@@ -435,7 +445,7 @@ public class AbstractUploadTest {
             ImmutableList.of(workspaceFile));
 
     FakeUpload underTest = new FakeUpload(BUCKET_URI,
-        sharedPublicly, forFailedJobs, pathPrefix,
+        sharedPublicly, forFailedJobs, showInline, pathPrefix,
         new MockUploadModule(executor),
         FAKE_DETAILS,
         uploads);
@@ -453,6 +463,7 @@ public class AbstractUploadTest {
   public void testTwoPartPrefix() throws Exception {
     final boolean sharedPublicly = false;
     final boolean forFailedJobs = true;
+    final boolean showInline = false;
     final String pathPrefix = null;
 
     final AbstractUpload.UploadSpec uploads =
@@ -460,7 +471,7 @@ public class AbstractUploadTest {
             ImmutableList.of(workspaceFile));
 
     FakeUpload underTest = new FakeUpload(BUCKET_URI + "/" + STORAGE_PREFIX,
-        sharedPublicly, forFailedJobs, pathPrefix,
+        sharedPublicly, forFailedJobs, showInline, pathPrefix,
         new MockUploadModule(executor),
         FAKE_DETAILS,
         uploads);
@@ -478,6 +489,7 @@ public class AbstractUploadTest {
   public void testRetryOnFailure() throws Exception {
     final boolean sharedPublicly = false;
     final boolean forFailedJobs = true;
+    final boolean showInline = false;
     final String pathPrefix = null;
 
     final AbstractUpload.UploadSpec uploads =
@@ -485,7 +497,7 @@ public class AbstractUploadTest {
             ImmutableList.of(workspaceFile));
 
     FakeUpload underTest = new FakeUpload(BUCKET_URI,
-        sharedPublicly, forFailedJobs, pathPrefix,
+        sharedPublicly, forFailedJobs, showInline, pathPrefix,
         new MockUploadModule(executor, 2 /* retries */),
         FAKE_DETAILS,
         uploads);
@@ -505,6 +517,7 @@ public class AbstractUploadTest {
   public void testRetryOnFailureStillFails() throws Exception {
     final boolean sharedPublicly = false;
     final boolean forFailedJobs = true;
+    final boolean showInline = false;
     final String pathPrefix = null;
 
     final AbstractUpload.UploadSpec uploads =
@@ -512,7 +525,7 @@ public class AbstractUploadTest {
             ImmutableList.of(workspaceFile));
 
     FakeUpload underTest = new FakeUpload(BUCKET_URI,
-        sharedPublicly, forFailedJobs, pathPrefix,
+        sharedPublicly, forFailedJobs, showInline, pathPrefix,
         new MockUploadModule(executor, 2 /* retries */),
         FAKE_DETAILS,
         uploads);
@@ -532,6 +545,7 @@ public class AbstractUploadTest {
   public void testRetryOn401() throws Exception {
     final boolean sharedPublicly = false;
     final boolean forFailedJobs = true;
+    final boolean showInline = false;
     final String pathPrefix = null;
     
     Bucket bucket = new Bucket();
@@ -543,7 +557,7 @@ public class AbstractUploadTest {
             ImmutableList.of(workspaceFile, workspaceFile2));
 
     FakeUpload underTest = new FakeUpload(BUCKET_URI,
-        sharedPublicly, forFailedJobs, pathPrefix,
+        sharedPublicly, forFailedJobs, showInline, pathPrefix,
         new MockUploadModule(executor), /* no retries */
         FAKE_DETAILS,
         uploads);
@@ -567,6 +581,7 @@ public class AbstractUploadTest {
   public void testRetryOn401StillFails() throws Exception {
     final boolean sharedPublicly = false;
     final boolean forFailedJobs = true;
+    final boolean showInline = false;
     final String pathPrefix = null;
     
     Bucket bucket = new Bucket();
@@ -578,7 +593,7 @@ public class AbstractUploadTest {
             ImmutableList.of(workspaceFile));
 
     FakeUpload underTest = new FakeUpload(BUCKET_URI,
-        sharedPublicly, forFailedJobs, pathPrefix,
+        sharedPublicly, forFailedJobs, showInline, pathPrefix,
         new MockUploadModule(executor), /* no retries */
         FAKE_DETAILS,
         uploads);
@@ -600,10 +615,11 @@ public class AbstractUploadTest {
   public void testNullUploadSpec() throws Exception {
     final boolean sharedPublicly = false;
     final boolean forFailedJobs = true;
+    final boolean showInline = false;
     final String pathPrefix = null;
 
     FakeUpload underTest = new FakeUpload(BUCKET_URI + "/" + STORAGE_PREFIX,
-        sharedPublicly, forFailedJobs, pathPrefix,
+        sharedPublicly, forFailedJobs, showInline, pathPrefix,
         new MockUploadModule(executor),
         FAKE_DETAILS,
         null /* uploads */);
@@ -616,13 +632,14 @@ public class AbstractUploadTest {
   public void testWorkspaceNoFiles() throws Exception {
     final boolean sharedPublicly = false;
     final boolean forFailedJobs = true;
+    final boolean showInline = false;
     final String pathPrefix = null;
 
     final AbstractUpload.UploadSpec uploads =
         new AbstractUpload.UploadSpec(workspace, ImmutableList.<FilePath>of());
 
     FakeUpload underTest = new FakeUpload(BUCKET_URI + "/" + STORAGE_PREFIX,
-        sharedPublicly, forFailedJobs, pathPrefix,
+        sharedPublicly, forFailedJobs, showInline, pathPrefix,
         new MockUploadModule(executor),
         FAKE_DETAILS,
         uploads);
@@ -639,13 +656,14 @@ public class AbstractUploadTest {
   public void testBucketConflict() throws Exception {
     final boolean sharedPublicly = false;
     final boolean forFailedJobs = true;
+    final boolean showInline = false;
     final String pathPrefix = null;
 
     final AbstractUpload.UploadSpec uploads =
         new AbstractUpload.UploadSpec(workspace, ImmutableList.<FilePath>of());
 
     FakeUpload underTest = new FakeUpload(BUCKET_URI,
-        sharedPublicly, forFailedJobs, pathPrefix,
+        sharedPublicly, forFailedJobs, showInline, pathPrefix,
         new MockUploadModule(executor),
         FAKE_DETAILS,
         uploads);
@@ -666,13 +684,14 @@ public class AbstractUploadTest {
   public void testBucketException() throws Exception {
     final boolean sharedPublicly = false;
     final boolean forFailedJobs = true;
+    final boolean showInline = false;
     final String pathPrefix = null;
 
     final AbstractUpload.UploadSpec uploads =
         new AbstractUpload.UploadSpec(workspace, ImmutableList.<FilePath>of());
 
     FakeUpload underTest = new FakeUpload(BUCKET_URI,
-        sharedPublicly, forFailedJobs, pathPrefix,
+        sharedPublicly, forFailedJobs, showInline, pathPrefix,
         new MockUploadModule(executor),
         FAKE_DETAILS,
         uploads);
@@ -687,6 +706,7 @@ public class AbstractUploadTest {
   public void testTrailingSlash() throws Exception {
     final boolean sharedPublicly = false;
     final boolean forFailedJobs = true;
+    final boolean showInline = false;
     final String pathPrefix = null;
 
     final AbstractUpload.UploadSpec uploads =
@@ -695,7 +715,7 @@ public class AbstractUploadTest {
 
     FakeUpload underTest = new FakeUpload(
         BUCKET_URI + "/" + STORAGE_PREFIX + "/",
-        sharedPublicly, forFailedJobs, pathPrefix,
+        sharedPublicly, forFailedJobs, showInline, pathPrefix,
         new MockUploadModule(executor),
         FAKE_DETAILS,
         uploads);
@@ -714,6 +734,7 @@ public class AbstractUploadTest {
   public void testSharedPublicly() throws Exception {
     final boolean sharedPublicly = true;
     final boolean forFailedJobs = true;
+    final boolean showInline = false;
     final String pathPrefix = null;
 
     final AbstractUpload.UploadSpec uploads =
@@ -721,7 +742,7 @@ public class AbstractUploadTest {
             ImmutableList.of(workspaceFile));
 
     FakeUpload underTest = new FakeUpload(BUCKET_URI,
-        sharedPublicly, forFailedJobs, pathPrefix,
+        sharedPublicly, forFailedJobs, showInline, pathPrefix,
         new MockUploadModule(executor),
         FAKE_DETAILS,
         uploads);
@@ -760,6 +781,7 @@ public class AbstractUploadTest {
   public void testNotShared() throws Exception {
     final boolean sharedPublicly = false;
     final boolean forFailedJobs = true;
+    final boolean showInline = false;
     final String pathPrefix = null;
 
     final AbstractUpload.UploadSpec uploads =
@@ -767,7 +789,7 @@ public class AbstractUploadTest {
             ImmutableList.of(workspaceFile));
 
     FakeUpload underTest = new FakeUpload(BUCKET_URI,
-        sharedPublicly, forFailedJobs, pathPrefix,
+        sharedPublicly, forFailedJobs, showInline, pathPrefix,
         new MockUploadModule(executor),
         FAKE_DETAILS,
         uploads);
@@ -795,6 +817,7 @@ public class AbstractUploadTest {
   public void upload_nofile() throws UploadException, IOException {
     final boolean sharedPublicly = false;
     final boolean forFailedJobs = true;
+    final boolean showInline = false;
     final String pathPrefix = null;
 
     FilePath nonExistentFile = workspace.child("non-existent-file");
@@ -803,7 +826,7 @@ public class AbstractUploadTest {
             ImmutableList.of(nonExistentFile));
 
     FakeUpload underTest = new FakeUpload(BUCKET_URI,
-        sharedPublicly, forFailedJobs, pathPrefix,
+        sharedPublicly, forFailedJobs, showInline, pathPrefix,
         new MockUploadModule(executor),
         FAKE_DETAILS,
         uploads);

--- a/src/test/java/com/google/jenkins/plugins/storage/ClassicUploadTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/ClassicUploadTest.java
@@ -67,6 +67,7 @@ public class ClassicUploadTest {
   private ClassicUpload underTest;
   private boolean sharedPublicly;
   private boolean forFailedJobs;
+  private boolean showInline;
   private boolean stripPathPrefix;
   private String pathPrefix;
 
@@ -127,11 +128,12 @@ public class ClassicUploadTest {
     glob = "bar.txt";
     sharedPublicly = false;
     forFailedJobs = false;
+    showInline = false;
     stripPathPrefix = false;
     pathPrefix = null;
     underTest = new ClassicUpload(bucket, sharedPublicly, forFailedJobs,
-        stripPathPrefix, pathPrefix, new MockUploadModule(executor), glob,
-        null /* legacy arg */, null /* legacy arg */);
+        showInline, stripPathPrefix, pathPrefix, new MockUploadModule(executor),
+        glob, null /* legacy arg */, null /* legacy arg */);
   }
 
   @Test
@@ -144,7 +146,7 @@ public class ClassicUploadTest {
   @WithoutJenkins
   public void testLegacyArgs() {
     ClassicUpload legacyVersion = new ClassicUpload(null /* bucket */,
-        sharedPublicly, forFailedJobs, stripPathPrefix, pathPrefix,
+        sharedPublicly, forFailedJobs, showInline, stripPathPrefix, pathPrefix,
         new MockUploadModule(executor), null /* glob */, bucket, glob);
     assertEquals(underTest.getBucket(), legacyVersion.getBucket());
     assertEquals(underTest.isSharedPublicly(),
@@ -156,7 +158,7 @@ public class ClassicUploadTest {
   @Test(expected = NullPointerException.class)
   @WithoutJenkins
   public void testCheckNullGlob() throws Exception {
-    new ClassicUpload(bucket, sharedPublicly, forFailedJobs,
+    new ClassicUpload(bucket, sharedPublicly, forFailedJobs, showInline,
         stripPathPrefix, pathPrefix, new MockUploadModule(executor), null,
         null /* legacy arg */, null /* legacy arg */);
   }
@@ -164,7 +166,7 @@ public class ClassicUploadTest {
   @Test
   public void testCheckNullOnNullables() throws Exception {
     // The upload should handle null for the other fields.
-    new ClassicUpload(bucket, sharedPublicly, forFailedJobs,
+    new ClassicUpload(bucket, sharedPublicly, forFailedJobs, showInline,
         false /* stripPathPrefix */, null /* pathPrefix */,
         null /* module */, glob, null /* legacy arg */, null /* legacy arg */);
   }

--- a/src/test/java/com/google/jenkins/plugins/storage/GoogleCloudStorageUploaderTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/GoogleCloudStorageUploaderTest.java
@@ -85,6 +85,7 @@ public class GoogleCloudStorageUploaderTest {
   private GoogleCloudStorageUploader underTest;
   private boolean sharedPublicly;
   private boolean forFailedJobs;
+  private boolean showInline;
   private boolean stripPathPrefix;
   private String pathPrefix;
 
@@ -167,11 +168,12 @@ public class GoogleCloudStorageUploaderTest {
     glob = "bar.txt";
     sharedPublicly = false;
     forFailedJobs = false;
+    showInline = false;
     stripPathPrefix = false;
     pathPrefix = null;
     underTest = new GoogleCloudStorageUploader(CREDENTIALS_ID,
         ImmutableList.<AbstractUpload>of(
-            new ClassicUpload(bucket, sharedPublicly, forFailedJobs,
+            new ClassicUpload(bucket, sharedPublicly, forFailedJobs, showInline,
                 stripPathPrefix, pathPrefix, new MockUploadModule(executor),
                 glob, null /* legacy arg*/, null /* legacy arg */)));
   }
@@ -232,7 +234,7 @@ public class GoogleCloudStorageUploaderTest {
     bucket = "bucket";
     underTest = new GoogleCloudStorageUploader(CREDENTIALS_ID,
         ImmutableList.<AbstractUpload>of(
-            new ClassicUpload(bucket, sharedPublicly, forFailedJobs,
+            new ClassicUpload(bucket, sharedPublicly, forFailedJobs, showInline,
                 stripPathPrefix, pathPrefix, new MockUploadModule(executor),
                 glob, null /* legacy arg */, null /* legacy arg */)));
 
@@ -281,7 +283,7 @@ public class GoogleCloudStorageUploaderTest {
     forFailedJobs = true;
     underTest = new GoogleCloudStorageUploader(CREDENTIALS_ID,
         ImmutableList.<AbstractUpload>of(
-            new ClassicUpload(bucket, sharedPublicly, forFailedJobs,
+            new ClassicUpload(bucket, sharedPublicly, forFailedJobs, showInline,
                 stripPathPrefix, pathPrefix, new MockUploadModule(executor),
                 glob, null /* legacy arg */, null /* legacy arg */)));
 
@@ -303,7 +305,7 @@ public class GoogleCloudStorageUploaderTest {
   public void testStdoutUpload() throws Exception {
     underTest = new GoogleCloudStorageUploader(CREDENTIALS_ID,
         ImmutableList.<AbstractUpload>of(
-            new StdoutUpload(bucket, sharedPublicly, forFailedJobs,
+            new StdoutUpload(bucket, sharedPublicly, forFailedJobs, showInline,
                 stripPathPrefix, pathPrefix, new MockUploadModule(executor),
                 "build-log.txt", null /* legacy arg */)));
 
@@ -324,7 +326,7 @@ public class GoogleCloudStorageUploaderTest {
     glob = "*.txt";
     underTest = new GoogleCloudStorageUploader(CREDENTIALS_ID,
         ImmutableList.<AbstractUpload>of(
-            new ClassicUpload(bucket, sharedPublicly, forFailedJobs,
+            new ClassicUpload(bucket, sharedPublicly, forFailedJobs, showInline,
                 stripPathPrefix, pathPrefix, new MockUploadModule(executor),
                 glob, null /* legacy arg */, null /* legacy arg */)));
 
@@ -346,7 +348,7 @@ public class GoogleCloudStorageUploaderTest {
     glob = absoluteFilePath;
     underTest = new GoogleCloudStorageUploader(CREDENTIALS_ID,
         ImmutableList.<AbstractUpload>of(
-            new ClassicUpload(bucket, sharedPublicly, forFailedJobs,
+            new ClassicUpload(bucket, sharedPublicly, forFailedJobs, showInline,
                 stripPathPrefix, pathPrefix, new MockUploadModule(executor),
                 glob, null /* legacy arg */, null /* legacy arg */)));
 
@@ -370,7 +372,7 @@ public class GoogleCloudStorageUploaderTest {
     glob = "/tmp/bar.*.txt";
     underTest = new GoogleCloudStorageUploader(CREDENTIALS_ID,
         ImmutableList.<AbstractUpload>of(
-            new ClassicUpload(bucket, sharedPublicly, forFailedJobs,
+            new ClassicUpload(bucket, sharedPublicly, forFailedJobs, showInline,
                 stripPathPrefix, pathPrefix, new MockUploadModule(executor),
                 glob, null /* legacy arg */, null /* legacy arg */)));
 
@@ -395,7 +397,7 @@ public class GoogleCloudStorageUploaderTest {
     glob = "bar.$BUILD_NUMBER.txt";
     underTest = new GoogleCloudStorageUploader(CREDENTIALS_ID,
         ImmutableList.<AbstractUpload>of(
-            new ClassicUpload(bucket, sharedPublicly, forFailedJobs,
+            new ClassicUpload(bucket, sharedPublicly, forFailedJobs, showInline,
                 stripPathPrefix, pathPrefix, new MockUploadModule(executor),
                 glob, null /* legacy arg */, null /* legacy arg */)));
 
@@ -417,7 +419,7 @@ public class GoogleCloudStorageUploaderTest {
     glob = "blah/bar.txt";
     underTest = new GoogleCloudStorageUploader(CREDENTIALS_ID,
         ImmutableList.<AbstractUpload>of(
-            new ClassicUpload(bucket, sharedPublicly, forFailedJobs,
+            new ClassicUpload(bucket, sharedPublicly, forFailedJobs, showInline,
                 stripPathPrefix, pathPrefix, new MockUploadModule(executor),
                 glob, null /* legacy arg */, null /* legacy arg */)));
 
@@ -439,7 +441,7 @@ public class GoogleCloudStorageUploaderTest {
     glob = "**/*.txt";
     underTest = new GoogleCloudStorageUploader(CREDENTIALS_ID,
         ImmutableList.<AbstractUpload>of(
-            new ClassicUpload(bucket, sharedPublicly, forFailedJobs,
+            new ClassicUpload(bucket, sharedPublicly, forFailedJobs, showInline,
                 stripPathPrefix, pathPrefix, new MockUploadModule(executor),
                 glob, null /* legacy arg */, null /* legacy arg */)));
 
@@ -461,7 +463,7 @@ public class GoogleCloudStorageUploaderTest {
     glob = "*.txt";
     underTest = new GoogleCloudStorageUploader(CREDENTIALS_ID,
         ImmutableList.<AbstractUpload>of(
-            new ClassicUpload(bucket, sharedPublicly, forFailedJobs,
+            new ClassicUpload(bucket, sharedPublicly, forFailedJobs, showInline,
                 stripPathPrefix, pathPrefix, new MockUploadModule(executor),
                 glob, null /* legacy arg */, null /* legacy arg */)));
 

--- a/src/test/java/com/google/jenkins/plugins/storage/HttpHeadersTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/HttpHeadersTest.java
@@ -28,12 +28,19 @@ public class HttpHeadersTest {
   public void testGetContentDisposition_ascii() {
     assertEquals(
         "attachment; filename=\"myapp.war\"; filename*=UTF-8''myapp.war",
-        HttpHeaders.getContentDisposition("myapp.war"));
+        HttpHeaders.getContentDisposition("myapp.war", false));
 
     assertEquals(
         "attachment; filename=\"contains space.txt\"; "
             + "filename*=UTF-8''contains%20space.txt",
-        HttpHeaders.getContentDisposition("contains space.txt"));
+        HttpHeaders.getContentDisposition("contains space.txt", false));
+  }
+
+  @Test
+  public void testGetContentDisposition_asciiInline() {
+    assertEquals(
+        "inline; filename=\"build-log.txt\"; filename*=UTF-8''build-log.txt",
+        HttpHeaders.getContentDisposition("build-log.txt", true));
   }
 
   @Test
@@ -41,28 +48,28 @@ public class HttpHeadersTest {
     assertEquals(
         "attachment; filename=\"snowman _.txt\"; "
             + "filename*=UTF-8''snowman%20%E2%98%83.txt",
-        HttpHeaders.getContentDisposition("snowman ☃.txt"));
+        HttpHeaders.getContentDisposition("snowman ☃.txt", false));
   }
 
   @Test
   public void testGetContentDisposition_unicodeNonBmp() {
     assertEquals(
         "attachment; filename=\"_.zip\"; filename*=UTF-8''%F0%9D%92%9E.zip",
-        HttpHeaders.getContentDisposition("𝒞.zip"));
+        HttpHeaders.getContentDisposition("𝒞.zip", false));
   }
 
   @Test
   public void testGetContentDisposition_rfc2616Escapes() {
     assertEquals(
         "attachment; filename=\"-\\\\-\\\"-\"; filename*=UTF-8''-%5C-%22-",
-        HttpHeaders.getContentDisposition("-\\-\"-"));
+        HttpHeaders.getContentDisposition("-\\-\"-", false));
   }
 
   @Test
   public void testGetContentDisposition_rfc5987IdentitySymbols() {
     assertEquals(
         "attachment; filename=\"!#$&+-.^_`|~\"; filename*=UTF-8''!#$&+-.^_`|~",
-        HttpHeaders.getContentDisposition("!#$&+-.^_`|~"));
+        HttpHeaders.getContentDisposition("!#$&+-.^_`|~", false));
   }
 
   @Test
@@ -71,6 +78,6 @@ public class HttpHeadersTest {
         "attachment; filename=\"@%*()=[]{}\\\\:;\\\"'<>,/?\"; "
             + "filename*=UTF-8''%40%25%2A%28%29%3D%5B%5D%7B%7D%5C%3A%3B%22%27"
             + "%3C%3E%2C%2F%3F",
-        HttpHeaders.getContentDisposition("@%*()=[]{}\\:;\"'<>,/?"));
+        HttpHeaders.getContentDisposition("@%*()=[]{}\\:;\"'<>,/?", false));
   }
 }


### PR DESCRIPTION
This fixes #7 by providing an option to indicate that files (such as the build log) should be viewable inline in the browser, rather than forcing a download.

By default no behavior is changed, but users can tick the checkbox to allow inline viewing of uploaded artifacts.