### PR TITLE
Added support for additional Content-Types (.js, .svg, woff2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/.classpath
+/.project
+/.settings
+/target

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
@@ -108,7 +108,8 @@ public abstract class AbstractUpload
       ImmutableMap.of(
         "css", "text/css",
         "js", "application/javascript",
-        "svg", "image/svg+xml"
+        "svg", "image/svg+xml",
+        "woff2", "font/woff2"
       );
 
   /**

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
@@ -106,7 +106,9 @@ public abstract class AbstractUpload
       Logger.getLogger(AbstractUpload.class.getName());
   private static final ImmutableMap<String, String> CONTENT_TYPES =
       ImmutableMap.of(
-        "css", "text/css"
+        "css", "text/css",
+        "js", "application/javascript",
+        "svg", "image/svg+xml"
       );
 
   /**

--- a/src/main/resources/com/google/jenkins/plugins/storage/AbstractUpload/help-showInline.html
+++ b/src/main/resources/com/google/jenkins/plugins/storage/AbstractUpload/help-showInline.html
@@ -1,5 +1,5 @@
 <div>
-  <p>This options controls the "Content-Disposition" HTTP header:</p>
+  <p>This option controls the "Content-Disposition" HTTP header:</p>
   <ul>
     <li>When this box is checked, file metadata will be configured with "Content-Disposition: inline" indicating it can be displayed inside a Web page, or as a Web page.</li>
     <li>When this box is left unchecked, file metadata will be configured with "Content-Disposition: attachment" indicating it should be downloaded.</li>

--- a/src/main/resources/com/google/jenkins/plugins/storage/AbstractUpload/help-showInline.html
+++ b/src/main/resources/com/google/jenkins/plugins/storage/AbstractUpload/help-showInline.html
@@ -1,7 +1,7 @@
 <div>
   <p>This options controls the "Content-Disposition" HTTP header:</p>
   <ul>
-    <li>When this box is checked, all files will be set with "Content-Disposition: inline" to be displayed in the browser.</li>
-    <li>When this box is unchecked, all files will be set with "Content-Disposition: attachment" which will trigger a file download by the browser.</li>
+    <li>When this box is checked, file metadata will be configured with "Content-Disposition: inline" indicating it can be displayed inside a Web page, or as a Web page.</li>
+    <li>When this box is left unchecked, file metadata will be configured with "Content-Disposition: attachment" indicating it should be downloaded.</li>
   </ul>
 </div>

--- a/src/main/resources/com/google/jenkins/plugins/storage/AbstractUpload/help-showInline.html
+++ b/src/main/resources/com/google/jenkins/plugins/storage/AbstractUpload/help-showInline.html
@@ -1,0 +1,7 @@
+<div>
+  <p>This options controls the "Content-Disposition" HTTP header:</p>
+  <ul>
+    <li>When this box is checked, all files will be set with "Content-Disposition: inline" to be displayed in the browser.</li>
+    <li>When this box is unchecked, all files will be set with "Content-Disposition: attachment" which will trigger a file download by the browser.</li>
+  </ul>
+</div>


### PR DESCRIPTION
This includes additional content-type definitions to fix #23.  It also includes help text for the 'showInline' field.