### PR TITLE
Updated expired slack invite link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Please file feature requests and bug reports as [GitHub Issues](https://github.c
 The GCP Jenkins community uses the **#gcp-jenkins** slack channel on
 [https://googlecloud-community.slack.com](https://googlecloud-community.slack.com)
 to ask questions and share feedback. Invitation link available
-[here](https://join.slack.com/t/googlecloud-community/shared_invite/enQtNDI2NjAyODQ4NzA5LThlOGVhMzUyNDUyNmVmNTQ5YzMxYmYxNDk1YjdmZjU4ZjBiYmU1OGEzYWE2MWY1NWY4NTQ1NjAwOWRlN2ZlN2I).
+here: [http://bit.ly/gcp-slack](http://bit.ly/gcp-slack).
 
 ## License
 See [LICENSE](LICENSE)


### PR DESCRIPTION
Switched to using bitly link so that future changes to README won't be required.