### PR TITLE
Whitelist fix

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
@@ -105,7 +105,7 @@ public abstract class AbstractUpload
   protected final transient UploadModule module;
   /** Provide detail information summarizing this download for the GCS upload report. */
   public abstract String getDetails();
-  /** NOTE: old name kept for deserialization */
+  // NOTE: old name kept for deserialization
   private final String bucketNameWithVars;
   private boolean sharedPublicly;
   private boolean forFailedJobs;
@@ -129,7 +129,7 @@ public abstract class AbstractUpload
 
   /**
    * This method allows the old signature for compatibility reasons. Calls {@link #perform(String,
-   * Run, FilePath, TaskListener)}
+   * Run, FilePath, TaskListener)}.
    *
    * @param credentialsId The unique ID for the credentials we are using to authenticate with GCS.
    * @param build Current build being run.
@@ -330,10 +330,10 @@ public abstract class AbstractUpload
   }
 
   /**
-   * Gives all registered {@link AbstractUpload}s See:
-   * https://wiki.jenkins-ci.org/display/JENKINS/Defining+a+new+extension+point
+   * Gives all registered {@link AbstractUpload}s.
+   * See: https://wiki.jenkins-ci.org/display/JENKINS/Defining+a+new+extension+point
    *
-   * @return All registered {@link AbstractUpload}s
+   * @return All registered {@link AbstractUpload}s.
    */
   public static DescriptorExtensionList<AbstractUpload, AbstractUploadDescriptor> all() {
     return checkNotNull(Hudson.getInstance())
@@ -350,7 +350,7 @@ public abstract class AbstractUpload
    * storagePrefix} using the authority of {@code credentials} and logging any information to {@code
    * listener}.
    *
-   * @throws UploadException if anything goes awry
+   * @throws UploadException If there was any issue during upload.
    */
   private void initiateUploadsAtWorkspace(
       final GoogleRobotCredentials credentials,

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
@@ -107,7 +107,6 @@ public abstract class AbstractUpload
   public abstract String getDetails();
   /** NOTE: old name kept for deserialization */
   private final String bucketNameWithVars;
-
   private boolean sharedPublicly;
   private boolean forFailedJobs;
   private boolean showInline;

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
@@ -107,6 +107,7 @@ public abstract class AbstractUpload
   public abstract String getDetails();
   /** NOTE: old name kept for deserialization */
   private final String bucketNameWithVars;
+
   private boolean sharedPublicly;
   private boolean forFailedJobs;
   private boolean showInline;
@@ -128,8 +129,8 @@ public abstract class AbstractUpload
   }
 
   /**
-   * This method allows the old signature for compatibility reasons. Calls {@link #perform(String, Run,
-   * FilePath, TaskListener)}
+   * This method allows the old signature for compatibility reasons. Calls {@link #perform(String,
+   * Run, FilePath, TaskListener)}
    *
    * @param credentialsId The unique ID for the credentials we are using to authenticate with GCS.
    * @param build Current build being run.
@@ -265,10 +266,7 @@ public abstract class AbstractUpload
     return bucketNameWithVars;
   }
 
-  /**
-   * @param sharedPublicly Whether to surface the file being uploaded to anyone with the
-   *     link.
-   */
+  /** @param sharedPublicly Whether to surface the file being uploaded to anyone with the link. */
   @DataBoundSetter
   public void setSharedPublicly(boolean sharedPublicly) {
     this.sharedPublicly = sharedPublicly;

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
@@ -128,7 +128,7 @@ public abstract class AbstractUpload
   }
 
   /**
-   * This method allows old signature for compatibility reasons. Calls {@link #perform(String, Run,
+   * This method allows the old signature for compatibility reasons. Calls {@link #perform(String, Run,
    * FilePath, TaskListener)}
    *
    * @param credentialsId The unique ID for the credentials we are using to authenticate with GCS.
@@ -143,7 +143,7 @@ public abstract class AbstractUpload
   }
 
   /**
-   * The main action entrypoint of this extension. This uploads the contents included by the
+   * The main action entry point of this extension. This uploads the contents included by the
    * implementation to our resolved storage bucket.
    *
    * @param credentialsId The unique ID for the credentials we are using to authenticate with GCS.
@@ -266,7 +266,7 @@ public abstract class AbstractUpload
   }
 
   /**
-   * @param sharedPublicly Returns whether to surface the file being uploaded to anyone with the
+   * @param sharedPublicly Whether to surface the file being uploaded to anyone with the
    *     link.
    */
   @DataBoundSetter
@@ -314,7 +314,7 @@ public abstract class AbstractUpload
    *     automatically added if it is missing.
    */
   @DataBoundSetter
-  public void setPathPrefix(String pathPrefix) {
+  public void setPathPrefix(@Nullable String pathPrefix) {
     if (pathPrefix != null && !pathPrefix.endsWith("/")) {
       pathPrefix += "/";
     }
@@ -327,6 +327,7 @@ public abstract class AbstractUpload
    *     <p>Filenames that do not start with this prefix will not be modified. Trailing slash is
    *     automatically added if it is missing.
    */
+  @Nullable
   public String getPathPrefix() {
     return pathPrefix;
   }

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
@@ -93,7 +93,6 @@ import org.kohsuke.stapler.DataBoundSetter;
 // TODO: Refactor to use StorageClient https://github.com/jenkinsci/google-storage-plugin/issues/71
 public abstract class AbstractUpload
     implements Describable<AbstractUpload>, ExtensionPoint, Serializable {
-
   private static final Logger logger = Logger.getLogger(AbstractUpload.class.getName());
   private static final ImmutableMap<String, String> CONTENT_TYPES =
       ImmutableMap.of(
@@ -101,6 +100,17 @@ public abstract class AbstractUpload
           "js", "application/javascript",
           "svg", "image/svg+xml",
           "woff2", "font/woff2");
+  private String pathPrefix;
+  /** The module to use for providing dependencies. */
+  protected final transient UploadModule module;
+  /** Provide detail information summarizing this download for the GCS upload report. */
+  public abstract String getDetails();
+  /** NOTE: old name kept for deserialization */
+  private final String bucketNameWithVars;
+
+  private boolean sharedPublicly;
+  private boolean forFailedJobs;
+  private boolean showInline;
 
   /**
    * Construct the base upload from a handful of universal properties.
@@ -118,7 +128,16 @@ public abstract class AbstractUpload
     this.bucketNameWithVars = checkNotNull(bucket);
   }
 
-  /** Allow old signature for compatibility. */
+  /**
+   * This method allows old signature for compatibility reasons. Calls {@link #perform(String, Run,
+   * FilePath, TaskListener)}
+   *
+   * @param credentialsId The unique ID for the credentials we are using to authenticate with GCS.
+   * @param build Current build being run.
+   * @param listener Listener for events of this job.
+   * @throws UploadException If there was an issue uploading/accessing the GCS API.
+   * @throws IOException If there was issue authenticating with credentialsId.
+   */
   public final void perform(String credentialsId, AbstractBuild<?, ?> build, TaskListener listener)
       throws UploadException, IOException {
     perform(credentialsId, build, build.getWorkspace(), listener);
@@ -127,6 +146,13 @@ public abstract class AbstractUpload
   /**
    * The main action entrypoint of this extension. This uploads the contents included by the
    * implementation to our resolved storage bucket.
+   *
+   * @param credentialsId The unique ID for the credentials we are using to authenticate with GCS.
+   * @param run Current job being run.
+   * @param workspace Workspace of node running the job.
+   * @param listener Listener for events of this job.
+   * @throws UploadException If there was an issue uploading/accessing the GCS API.
+   * @throws IOException If there was issue authenticating with credentialsId.
    */
   public final void perform(
       String credentialsId, Run<?, ?> run, FilePath workspace, TaskListener listener)
@@ -188,9 +214,6 @@ public abstract class AbstractUpload
   protected abstract UploadSpec getInclusions(
       Run<?, ?> run, FilePath workspace, TaskListener listener) throws UploadException;
 
-  /** Provide detail information summarizing this download for the GCS upload report. */
-  public abstract String getDetails();
-
   /**
    * This hook is intended to give implementations the opportunity to further annotate the {@link
    * StorageObject} with metadata before uploading it to cloud storage.
@@ -212,7 +235,12 @@ public abstract class AbstractUpload
     return MetadataContainer.of(run).getSerializedMetadata();
   }
 
-  /** Determine whether we should upload the pattern for the given build result. */
+  /**
+   * Determine whether we should upload the pattern for the given build result.
+   *
+   * @param result Result of the build run.
+   * @return Whether we should upload the pattern for the given build result.
+   */
   public boolean forResult(Result result) {
     if (result == null) {
       // We might have unfinished builds, e.g., through pipeline of Build Step.
@@ -231,91 +259,91 @@ public abstract class AbstractUpload
   }
 
   /**
-   * The bucket name specified by the user, which potentially contains unresolved symbols, such as
-   * $JOB_NAME and $BUILD_NUMBER.
+   * @return The bucket name specified by the user, which potentially contains unresolved symbols,
+   *     such as $JOB_NAME and $BUILD_NUMBER.
    */
   public String getBucket() {
     return bucketNameWithVars;
   }
 
-  /** NOTE: old name kept for deserialization */
-  private final String bucketNameWithVars;
-
-  /** Whether to surface the file being uploaded to anyone with the link. */
+  /**
+   * @param sharedPublicly Returns whether to surface the file being uploaded to anyone with the
+   *     link.
+   */
   @DataBoundSetter
   public void setSharedPublicly(boolean sharedPublicly) {
     this.sharedPublicly = sharedPublicly;
   }
 
+  /** @return Whether to surface the file being uploaded to anyone with the link. */
   public boolean isSharedPublicly() {
     return sharedPublicly;
   }
 
-  private boolean sharedPublicly;
-
-  /** Whether to attempt the upload, even if the job failed. */
+  /** @param forFailedJobs Whether to attempt the upload, even if the job failed. */
   @DataBoundSetter
   public void setForFailedJobs(boolean forFailedJobs) {
     this.forFailedJobs = forFailedJobs;
   }
 
+  /** @return Whether to attempt the upload, even if the job failed. */
   public boolean isForFailedJobs() {
     return forFailedJobs;
   }
 
-  private boolean forFailedJobs;
-
   /**
-   * Whether to indicate in metadata that the file should be viewable inline in web browsers, rather
-   * than requiring it to be downloaded first.
+   * @param showInline Set whether to indicate in metadata that the file should be viewable inline
+   *     in web browsers, rather than requiring it to be downloaded first.
    */
   @DataBoundSetter
   public void setShowInline(boolean showInline) {
     this.showInline = showInline;
   }
 
+  /**
+   * @return Whether to indicate in metadata that the file should be viewable inline in web
+   *     browsers, rather than requiring it to be downloaded first.
+   */
   public boolean isShowInline() {
     return showInline;
   }
 
-  private boolean showInline;
-
   /**
-   * The path prefix that will be stripped from uploaded files. May be null if no path prefix needs
-   * to be stripped.
-   *
-   * <p>Filenames that do not start with this prefix will not be modified. Trailing slash is
-   * automatically added if it is missing.
+   * @param pathPrefix The path prefix that will be stripped from uploaded files. May be null if no
+   *     path prefix needs to be stripped.
+   *     <p>Filenames that do not start with this prefix will not be modified. Trailing slash is
+   *     automatically added if it is missing.
    */
   @DataBoundSetter
-  public void setPathPrefix(@Nullable String pathPrefix) {
+  public void setPathPrefix(String pathPrefix) {
     if (pathPrefix != null && !pathPrefix.endsWith("/")) {
       pathPrefix += "/";
     }
     this.pathPrefix = pathPrefix;
   }
 
-  @Nullable
+  /**
+   * @return The path prefix that will be stripped from uploaded files. May be null if no path
+   *     prefix needs to be stripped.
+   *     <p>Filenames that do not start with this prefix will not be modified. Trailing slash is
+   *     automatically added if it is missing.
+   */
   public String getPathPrefix() {
     return pathPrefix;
   }
 
-  private String pathPrefix;
-
-  /** The module to use for providing dependencies. */
-  protected final UploadModule module;
-
   /**
-   * Boilerplate, see: https://wiki.jenkins-ci.org/display/JENKINS/Defining+a+new+extension+point
+   * Gives all registered {@link AbstractUpload}s See:
+   * https://wiki.jenkins-ci.org/display/JENKINS/Defining+a+new+extension+point
+   *
+   * @return All registered {@link AbstractUpload}s
    */
   public static DescriptorExtensionList<AbstractUpload, AbstractUploadDescriptor> all() {
     return checkNotNull(Hudson.getInstance())
         .<AbstractUpload, AbstractUploadDescriptor>getDescriptorList(AbstractUpload.class);
   }
 
-  /**
-   * Boilerplate, see: https://wiki.jenkins-ci.org/display/JENKINS/Defining+a+new+extension+point
-   */
+  /** {@inheritDoc} */
   public AbstractUploadDescriptor getDescriptor() {
     return (AbstractUploadDescriptor) checkNotNull(Hudson.getInstance()).getDescriptor(getClass());
   }

--- a/src/main/java/com/google/jenkins/plugins/storage/ClassicUploadStep.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/ClassicUploadStep.java
@@ -47,7 +47,7 @@ public class ClassicUploadStep extends Builder implements SimpleBuildStep, Seria
   private final String credentialsId;
 
   /**
-   * DataBoundConstructor for the classic upload step
+   * DataBoundConstructor for the classic upload step.
    *
    * @see ClassicUpload#ClassicUpload
    * @param credentialsId The unique ID for the credentials we are using to authenticate with GCS.
@@ -222,7 +222,7 @@ public class ClassicUploadStep extends Builder implements SimpleBuildStep, Seria
       return ClassicUpload.DescriptorImpl.staticDoCheckBucket(bucket);
     }
 
-    /** This callback validates the {@code pattern} input field's values */
+    /** This callback validates the {@code pattern} input field's values. */
     public static FormValidation doCheckPattern(@QueryParameter final String pattern)
         throws IOException {
       return ClassicUpload.DescriptorImpl.staticDoCheckPattern(pattern);

--- a/src/main/java/com/google/jenkins/plugins/storage/ClassicUploadStep.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/ClassicUploadStep.java
@@ -28,7 +28,6 @@ import hudson.tasks.Builder;
 import hudson.util.FormValidation;
 import java.io.IOException;
 import java.io.Serializable;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONObject;
@@ -39,15 +38,23 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
 /**
- * This upload extension implements the classical upload pattern where a user provides an Ant-style
- * glob, e.g. ** /*.java relative to the build workspace, and those files are uploaded to the
- * storage bucket.
+ * Build Step wrapper for {@link ClassicUpload}. Can be run as a build step or in pipelines during
+ * build and/or post-build.
  */
 @RequiresDomain(StorageScopeRequirement.class)
 public class ClassicUploadStep extends Builder implements SimpleBuildStep, Serializable {
+  private ClassicUpload upload;
+  private final String credentialsId;
 
-  @Nonnull private ClassicUpload upload;
-
+  /**
+   * DataBoundConstructor for the classic upload step
+   *
+   * @see ClassicUpload#ClassicUpload
+   * @param credentialsId The unique ID for the credentials we are using to authenticate with GCS.
+   * @param bucket GCS bucket to upload build artifacts to.
+   * @param pattern The glob of files to upload, which potentially contains unresolved symbols, such
+   *     as $JOB_NAME and $BUILD_NUMBER.
+   */
   @DataBoundConstructor
   public ClassicUploadStep(String credentialsId, String bucket, String pattern) {
     this(credentialsId, bucket, null, pattern);
@@ -57,6 +64,11 @@ public class ClassicUploadStep extends Builder implements SimpleBuildStep, Seria
    * Construct the classic upload step.
    *
    * @see ClassicUpload#ClassicUpload
+   * @param credentialsId The unique ID for the credentials we are using to authenticate with GCS.
+   * @param bucket GCS bucket to upload build artifacts to.
+   * @param module Helper class for connecting to the GCS API.
+   * @param pattern The glob of files to upload, which potentially contains unresolved symbols, such
+   *     as $JOB_NAME and $BUILD_NUMBER.
    */
   public ClassicUploadStep(
       String credentialsId, String bucket, @Nullable UploadModule module, String pattern) {
@@ -72,66 +84,93 @@ public class ClassicUploadStep extends Builder implements SimpleBuildStep, Seria
     upload.setForFailedJobs(true);
   }
 
-  /** Whether to surface the file being uploaded to anyone with the link. */
+  /** @param sharedPublicly Whether to surface the file being uploaded to anyone with the link. */
   @DataBoundSetter
   public void setSharedPublicly(boolean sharedPublicly) {
     upload.setSharedPublicly(sharedPublicly);
   }
 
+  /** @return Whether to surface the file being uploaded to anyone with the link. */
   public boolean isSharedPublicly() {
     return upload.isSharedPublicly();
   }
 
   /**
-   * Whether to indicate in metadata that the file should be viewable inline in web browsers, rather
-   * than requiring it to be downloaded first.
+   * @param showInline Whether to indicate in metadata that the file should be viewable inline in
+   *     web browsers, rather than requiring it to be downloaded first.
    */
   @DataBoundSetter
   public void setShowInline(boolean showInline) {
     upload.setShowInline(showInline);
   }
 
+  /**
+   * @return Whether to indicate in metadata that the file should be viewable inline in web
+   *     browsers, rather than requiring it to be downloaded first.
+   */
   public boolean isShowInline() {
     return upload.isShowInline();
   }
 
   /**
-   * The path prefix that will be stripped from uploaded files. May be null if no path prefix needs
-   * to be stripped.
-   *
-   * <p>Filenames that do not start with this prefix will not be modified. Trailing slash is
-   * automatically added if it is missing.
+   * @param pathPrefix The path prefix that will be stripped from uploaded files. May be null if no
+   *     path prefix needs to be stripped.
+   *     <p>Filenames that do not start with this prefix will not be modified. Trailing slash is
+   *     automatically added if it is missing.
    */
   @DataBoundSetter
   public void setPathPrefix(@Nullable String pathPrefix) {
     upload.setPathPrefix(pathPrefix);
   }
 
+  /**
+   * @return pathPrefix The path prefix that will be stripped from uploaded files. May be null if no
+   *     path prefix needs to be stripped.
+   *     <p>Filenames that do not start with this prefix will not be modified. Trailing slash is
+   *     automatically added if it is missing.
+   */
   @Nullable
   public String getPathPrefix() {
     return upload.getPathPrefix();
   }
 
+  /**
+   * @return The glob of files to upload, which potentially contains unresolved symbols, such as
+   *     $JOB_NAME and $BUILD_NUMBER.
+   */
   public String getPattern() {
     return upload.getPattern();
   }
 
+  /**
+   * @return The bucket name specified by the user, which potentially contains unresolved symbols,
+   *     such as $JOB_NAME and $BUILD_NUMBER.
+   */
   public String getBucket() {
     return upload.getBucket();
   }
 
-  /** The unique ID for the credentials we are using to authenticate with GCS. */
+  /** @return The unique ID for the credentials we are using to authenticate with GCS. */
   public String getCredentialsId() {
     return credentialsId;
   }
 
-  private final String credentialsId;
-
+  /** {@inheritDoc} */
   @Override
   public BuildStepMonitor getRequiredMonitorService() {
     return BuildStepMonitor.NONE;
   }
 
+  /**
+   * The main entry point of this extension. Uploads files that match an Ant-style glob, e.g. ** /
+   * *.java relative to the build workspace to a GCS bucket.
+   *
+   * @param run Current job being run.
+   * @param workspace Workspace of node running the job.
+   * @param launcher {@link Launcher} for this job.
+   * @param listener Listener for events of this job.
+   * @throws IOException If there was an issue performing the upload.
+   */
   @Override
   public void perform(Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener listener)
       throws IOException {
@@ -164,6 +203,7 @@ public class ClassicUploadStep extends Builder implements SimpleBuildStep, Seria
       return true;
     }
 
+    /** {@inheritDoc} */
     @Override
     public Builder newInstance(StaplerRequest req, JSONObject formData) throws FormException {
       // Since the config form lists the optional parameter pathPrefix as
@@ -182,6 +222,7 @@ public class ClassicUploadStep extends Builder implements SimpleBuildStep, Seria
       return ClassicUpload.DescriptorImpl.staticDoCheckBucket(bucket);
     }
 
+    /** This callback validates the {@code pattern} input field's values */
     public static FormValidation doCheckPattern(@QueryParameter final String pattern)
         throws IOException {
       return ClassicUpload.DescriptorImpl.staticDoCheckPattern(pattern);

--- a/src/main/java/com/google/jenkins/plugins/storage/DownloadStep.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/DownloadStep.java
@@ -166,7 +166,7 @@ public class DownloadStep extends Builder implements SimpleBuildStep, Serializab
     return GoogleRobotCredentials.getById(getCredentialsId());
   }
 
-  /** @inheritDoc */
+  /** @{inheritDoc} */
   @Override
   public BuildStepMonitor getRequiredMonitorService() {
     return BuildStepMonitor.NONE;

--- a/src/main/java/com/google/jenkins/plugins/storage/DownloadStep.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/DownloadStep.java
@@ -67,7 +67,7 @@ import org.kohsuke.stapler.StaplerRequest;
 /** A step to allow Download from Google Cloud Storage as a Build step and in pipeline. */
 @RequiresDomain(value = StorageScopeRequirement.class)
 public class DownloadStep extends Builder implements SimpleBuildStep, Serializable {
-
+  private static final long serialVersionUID = 1;
   private static final Logger logger = Logger.getLogger(DownloadStep.class.getName());
 
   /** Construct the download step. */

--- a/src/main/java/com/google/jenkins/plugins/storage/DownloadStep.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/DownloadStep.java
@@ -69,13 +69,33 @@ import org.kohsuke.stapler.StaplerRequest;
 public class DownloadStep extends Builder implements SimpleBuildStep, Serializable {
   private static final long serialVersionUID = 1;
   private static final Logger logger = Logger.getLogger(DownloadStep.class.getName());
+  private final String credentialsId;
+  private final String bucketUri;
+  private final String localDirectory;
+  private String pathPrefix;
+  /** The module to use for providing dependencies. */
+  protected final transient UploadModule module;
 
-  /** Construct the download step. */
+  /**
+   * DataBoundConstructor for DownloadStep.
+   *
+   * @param credentialsId The unique ID for the credentials we are using to authenticate with GCS.
+   * @param bucketUri Name of the GCS bucket. e.g. gs://MY_BUCKET_NAME
+   * @param localDirectory Path of the local directory in Jenkins to download the file to.
+   */
   @DataBoundConstructor
   public DownloadStep(String credentialsId, String bucketUri, String localDirectory) {
     this(credentialsId, bucketUri, localDirectory, null);
   }
 
+  /**
+   * Constructor for DownloadStep.
+   *
+   * @param credentialsId The unique ID for the credentials we are using to authenticate with GCS.
+   * @param bucketUri Name of the GCS bucket. e.g. gs://MY_BUCKET_NAME
+   * @param localDirectory Path of the local directory in Jenkins to download the file to.
+   * @param module An {@link UploadModule} to use for execution.
+   */
   public DownloadStep(
       String credentialsId,
       String bucketUri,
@@ -93,27 +113,24 @@ public class DownloadStep extends Builder implements SimpleBuildStep, Serializab
   }
 
   /**
-   * The bucket uri specified by the user, which potentially contains unresolved symbols, such as
-   * $JOB_NAME and $BUILD_NUMBER.
+   * @return The bucket uri specified by the user, which potentially contains
+   * unresolved symbols, such as $JOB_NAME and $BUILD_NUMBER.
    */
   public String getBucketUri() {
     return bucketUri;
   }
 
-  private final String bucketUri;
-
   /**
-   * The local directory in the Jenkins workspace that will receive the files. This might contain
+   * @return The local directory in the Jenkins workspace that will receive the files. This might contain
    * unresolved symbols, such as $JOB_NAME and $BUILD_NUMBER.
    */
   public String getLocalDirectory() {
     return localDirectory;
   }
 
-  private final String localDirectory;
 
   /**
-   * The path prefix that will be stripped from downloaded files. May be null if no path prefix
+   * @param pathPrefix The path prefix that will be stripped from downloaded files. May be null if no path prefix
    * needs to be stripped.
    *
    * <p>Filenames that do not start with this prefix will not be modified. Trailing slash is
@@ -127,33 +144,46 @@ public class DownloadStep extends Builder implements SimpleBuildStep, Serializab
     this.pathPrefix = pathPrefix;
   }
 
+  /**
+   * @return The path prefix that will be stripped from downloaded files. May
+   * be null if no path prefix needs to be stripped.
+   *
+   * <p>Filenames that do not start with this prefix will not be
+   *    modified. Trailing slash is automatically added if it is missing.
+   */
   @Nullable
   public String getPathPrefix() {
     return pathPrefix;
   }
 
-  private String pathPrefix;
-
-  /** The module to use for providing dependencies. */
-  protected final transient UploadModule module;
-
-  /** The unique ID for the credentials we are using to authenticate with GCS. */
+  /** @return The unique ID for the credentials we are using to authenticate with GCS. */
   public String getCredentialsId() {
     return credentialsId;
   }
 
-  private final String credentialsId;
-
-  /** The credentials we are using to authenticate with GCS. */
+  /** @return The credentials we are using to authenticate with GCS. */
   public GoogleRobotCredentials getCredentials() {
     return GoogleRobotCredentials.getById(getCredentialsId());
   }
 
+  /** @inheritDoc */
   @Override
   public BuildStepMonitor getRequiredMonitorService() {
     return BuildStepMonitor.NONE;
   }
 
+  /**
+   * The main entry point of this extension. Downloads the resolved GCS objects from the resolved
+   * GCS bucket to a local directory.
+   *
+   * @param run Current job being run.
+   * @param workspace Workspace of node running the job.
+   * @param launcher {@link Launcher} for this job.
+   * @param listener Listener for events of this job.
+   * @throws IOException If there was an issue parsing the bucket URI.
+   * @throws InterruptedException If there was an issue initiating downloads at
+   * workspace or expanding variables in the pathPrefix.
+   */
   @Override
   public void perform(
       @Nonnull Run<?, ?> run,
@@ -315,10 +345,13 @@ public class DownloadStep extends Builder implements SimpleBuildStep, Serializab
   }
 
   /**
-   * Split the string on wildcards.
+   * Split the string on wildcards ("*").
    *
-   * <p>String.split removes trailing empty strings, for example, "a", "a*" and "a**" and would
-   * procude the same result, so that method is not suitable.
+   * <p>String.split removes trailing empty strings, for example, "a",
+   *    "a*" and "a**" and would produce the same result, so that method is not suitable.
+   * @param uri URI supplied to be split.
+   * @return URI split by "*" wildcard.
+   * @throws AbortException
    */
   public static String[] split(String uri) throws AbortException {
     int occurs = StringUtils.countMatches(uri, "*");
@@ -334,6 +367,7 @@ public class DownloadStep extends Builder implements SimpleBuildStep, Serializab
     int index = uri.indexOf('*');
     return new String[] {uri.substring(0, index), uri.substring(index + 1)};
   }
+
   /** Verifies that the given path is supported within current limitations */
   private static void verifySupported(BucketPath path) throws AbortException {
     if (path.getBucket().contains("*")) {
@@ -413,7 +447,7 @@ public class DownloadStep extends Builder implements SimpleBuildStep, Serializab
   }
 
   /**
-   * Boilerplate, see: https://wiki.jenkins-ci.org/display/JENKINS/Defining+a+new+extension+point
+   * {@inheritDoc}
    */
   public DescriptorImpl getDescriptor() {
     return (DescriptorImpl) checkNotNull(Hudson.getInstance()).getDescriptor(getClass());
@@ -423,13 +457,18 @@ public class DownloadStep extends Builder implements SimpleBuildStep, Serializab
   @Extension
   @Symbol("googleStorageDownload")
   public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
-
     private final UploadModule module;
 
+    /**
+     * @return Module for the DescriptorImpl.
+     */
     public UploadModule getModule() {
       return module;
     }
 
+    /**
+     * Constructor for {@link DownloadStep}'s DescriptorImpl.
+     */
     public DescriptorImpl() {
       this.module = new UploadModule();
     }
@@ -446,6 +485,7 @@ public class DownloadStep extends Builder implements SimpleBuildStep, Serializab
       return true;
     }
 
+    /** {@inheritDoc} */
     @Override
     public Builder newInstance(StaplerRequest req, JSONObject formData) throws FormException {
       if (Boolean.FALSE.equals(formData.remove("stripPathPrefix"))) {

--- a/src/main/java/com/google/jenkins/plugins/storage/DownloadStep.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/DownloadStep.java
@@ -113,28 +113,26 @@ public class DownloadStep extends Builder implements SimpleBuildStep, Serializab
   }
 
   /**
-   * @return The bucket uri specified by the user, which potentially contains
-   * unresolved symbols, such as $JOB_NAME and $BUILD_NUMBER.
+   * @return The bucket uri specified by the user, which potentially contains unresolved symbols,
+   *     such as $JOB_NAME and $BUILD_NUMBER.
    */
   public String getBucketUri() {
     return bucketUri;
   }
 
   /**
-   * @return The local directory in the Jenkins workspace that will receive the files. This might contain
-   * unresolved symbols, such as $JOB_NAME and $BUILD_NUMBER.
+   * @return The local directory in the Jenkins workspace that will receive the files. This might
+   *     contain unresolved symbols, such as $JOB_NAME and $BUILD_NUMBER.
    */
   public String getLocalDirectory() {
     return localDirectory;
   }
 
-
   /**
-   * @param pathPrefix The path prefix that will be stripped from downloaded files. May be null if no path prefix
-   * needs to be stripped.
-   *
-   * <p>Filenames that do not start with this prefix will not be modified. Trailing slash is
-   * automatically added if it is missing.
+   * @param pathPrefix The path prefix that will be stripped from downloaded files. May be null if
+   *     no path prefix needs to be stripped.
+   *     <p>Filenames that do not start with this prefix will not be modified. Trailing slash is
+   *     automatically added if it is missing.
    */
   @DataBoundSetter
   public void setPathPrefix(@Nullable String pathPrefix) {
@@ -145,11 +143,10 @@ public class DownloadStep extends Builder implements SimpleBuildStep, Serializab
   }
 
   /**
-   * @return The path prefix that will be stripped from downloaded files. May
-   * be null if no path prefix needs to be stripped.
-   *
-   * <p>Filenames that do not start with this prefix will not be
-   *    modified. Trailing slash is automatically added if it is missing.
+   * @return The path prefix that will be stripped from downloaded files. May be null if no path
+   *     prefix needs to be stripped.
+   *     <p>Filenames that do not start with this prefix will not be modified. Trailing slash is
+   *     automatically added if it is missing.
    */
   @Nullable
   public String getPathPrefix() {
@@ -181,8 +178,8 @@ public class DownloadStep extends Builder implements SimpleBuildStep, Serializab
    * @param launcher {@link Launcher} for this job.
    * @param listener Listener for events of this job.
    * @throws IOException If there was an issue parsing the bucket URI.
-   * @throws InterruptedException If there was an issue initiating downloads at
-   * workspace or expanding variables in the pathPrefix.
+   * @throws InterruptedException If there was an issue initiating downloads at workspace or
+   *     expanding variables in the pathPrefix.
    */
   @Override
   public void perform(
@@ -347,8 +344,9 @@ public class DownloadStep extends Builder implements SimpleBuildStep, Serializab
   /**
    * Split the string on wildcards ("*").
    *
-   * <p>String.split removes trailing empty strings, for example, "a",
-   *    "a*" and "a**" and would produce the same result, so that method is not suitable.
+   * <p>String.split removes trailing empty strings, for example, "a", "a*" and "a**" and would
+   * produce the same result, so that method is not suitable.
+   *
    * @param uri URI supplied to be split.
    * @return URI split by "*" wildcard.
    * @throws AbortException
@@ -446,9 +444,7 @@ public class DownloadStep extends Builder implements SimpleBuildStep, Serializab
     return result;
   }
 
-  /**
-   * {@inheritDoc}
-   */
+  /** {@inheritDoc} */
   public DescriptorImpl getDescriptor() {
     return (DescriptorImpl) checkNotNull(Hudson.getInstance()).getDescriptor(getClass());
   }
@@ -459,16 +455,12 @@ public class DownloadStep extends Builder implements SimpleBuildStep, Serializab
   public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
     private final UploadModule module;
 
-    /**
-     * @return Module for the DescriptorImpl.
-     */
+    /** @return Module for the DescriptorImpl. */
     public UploadModule getModule() {
       return module;
     }
 
-    /**
-     * Constructor for {@link DownloadStep}'s DescriptorImpl.
-     */
+    /** Constructor for {@link DownloadStep}'s DescriptorImpl. */
     public DescriptorImpl() {
       this.module = new UploadModule();
     }

--- a/src/main/java/com/google/jenkins/plugins/storage/DownloadStep.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/DownloadStep.java
@@ -135,7 +135,7 @@ public class DownloadStep extends Builder implements SimpleBuildStep, Serializab
   private String pathPrefix;
 
   /** The module to use for providing dependencies. */
-  protected final UploadModule module;
+  protected final transient UploadModule module;
 
   /** The unique ID for the credentials we are using to authenticate with GCS. */
   public String getCredentialsId() {

--- a/src/main/java/com/google/jenkins/plugins/storage/UploadModule.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/UploadModule.java
@@ -25,7 +25,6 @@ import com.google.jenkins.plugins.util.Executor;
 import hudson.Plugin;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Serializable;
 import java.security.GeneralSecurityException;
 import jenkins.model.Jenkins;
 
@@ -34,7 +33,7 @@ import jenkins.model.Jenkins;
  * service.
  */
 @RequiresDomain(value = StorageScopeRequirement.class)
-public class UploadModule implements Serializable {
+public class UploadModule {
 
   /**
    * Interface for requesting the {@link Executor} for executing requests.
@@ -90,6 +89,15 @@ public class UploadModule implements Serializable {
   public InputStream executeMediaAsInputStream(Storage.Objects.Get getObject) throws IOException {
     return getObject.executeMediaAsInputStream();
   }
+
+  //  private void writeObject(java.io.ObjectOutputStream stream) throws java.io.IOException {
+  //    throw new java.io.NotSerializableException(getClass().getName());
+  //  }
+  //
+  //  private void readObject(java.io.ObjectInputStream stream)
+  //      throws java.io.IOException, ClassNotFoundException {
+  //    throw new java.io.NotSerializableException(getClass().getName());
+  //  }
 
   private static final String PLUGIN_NAME = "google-storage-plugin";
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/UploadModule.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/UploadModule.java
@@ -90,14 +90,5 @@ public class UploadModule {
     return getObject.executeMediaAsInputStream();
   }
 
-  //  private void writeObject(java.io.ObjectOutputStream stream) throws java.io.IOException {
-  //    throw new java.io.NotSerializableException(getClass().getName());
-  //  }
-  //
-  //  private void readObject(java.io.ObjectInputStream stream)
-  //      throws java.io.IOException, ClassNotFoundException {
-  //    throw new java.io.NotSerializableException(getClass().getName());
-  //  }
-
   private static final String PLUGIN_NAME = "google-storage-plugin";
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/UploadModule.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/UploadModule.java
@@ -40,7 +40,7 @@ public class UploadModule {
   /**
    * Interface for requesting the {@link Executor} for executing requests.
    *
-   * @return a new {@link Executor} instance for issuing requests
+   * @return a new {@link Executor} instance for issuing requests.
    */
   public Executor newExecutor() {
     return new Executor.Default();
@@ -55,7 +55,7 @@ public class UploadModule {
     return DomainRequirementProvider.of(getClass(), StorageScopeRequirement.class);
   }
 
-  /** @return the version number of this plugin */
+  /** @return the version number of this plugin. */
   public String getVersion() {
     String version = "";
     Plugin plugin = Jenkins.getInstance().getPlugin(PLUGIN_NAME);


### PR DESCRIPTION
This addresses an issue with [JEP-200](https://jenkins.io/blog/2018/01/13/jep-200/) when we upgrade Jenkins to 2.164.

 * To summarize, after 2.102, classes that needed to be deserialized had to be whitelisted by Jenkins.

 * DownloadStepTest was having issues passing because MockExecutor had a non-whitelisted class to serialize (Storage.model.Objects).

By making the UploadModule transient, it is not deserialized and resolves the issue. UploadModule contains helper functions only and thus would not need to be serializable. This will also not be an issue once #71 is complete.

Also added method headers to all the steps if not already there.

Passed mvn verify.