### PR TITLE
Add class level concurrency for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 # Jenkins home directory when running "mvn hpi:run".
 /work
+
+# Maven surefire statistics file for determining test run order
+.surefire-*

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
     <google.api.version>1.24.1</google.api.version>
     <java.level>8</java.level>
     <pipeline-model-definition.version>1.3.8</pipeline-model-definition.version>
+    <concurrency>5</concurrency>
   </properties>
 
   <dependencies>
@@ -284,6 +285,7 @@
         <version>2.20.1</version>
         <configuration>
           <skipTests>${skip.surefire.tests}</skipTests>
+          <runOrder>balanced</runOrder>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
@@ -330,8 +330,8 @@ public abstract class AbstractUpload
   }
 
   /**
-   * Gives all registered {@link AbstractUpload}s.
-   * See: https://wiki.jenkins-ci.org/display/JENKINS/Defining+a+new+extension+point
+   * Gives all registered {@link AbstractUpload}s. See:
+   * https://wiki.jenkins-ci.org/display/JENKINS/Defining+a+new+extension+point
    *
    * @return All registered {@link AbstractUpload}s.
    */


### PR DESCRIPTION
There is trade-off in terms of how many concurrent threads to use here, which is that the more threads you use, the slower each thread is. It should be at least 4 so that each integration tests class is run in parallel, and I saw better performance with 5. This change sped up the overall runtime of the verify command on my machine from over **5m30s** to under **2m20s**.

The slowest test is the `ExpiringBucketLifecycleManagerStepTest`, so ideally that would run in the first batch, but it did not because the default test ordering is alphanumeric. Because setting the concurrent property means the classes are run in parallel, we can use the [`runOrder`](http://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#runOrder) property for the unit tests set to `balanced`. With this `runOrder` value, for a given pom configuration the plugin will generate a statistics file and update it on subsequent test runs to optimize the test order. As expected, `ExpiringBucketLifecycleManagerStepTest` runs first and finishes after the other test classes, so it is now the bottleneck.

