### PR TITLE
Javadoc fix for release.

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractBucketLifecycleManager.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractBucketLifecycleManager.java
@@ -148,8 +148,9 @@ public abstract class AbstractBucketLifecycleManager extends AbstractUpload {
    * This is intended to be an identity function that throws when the input is not adequately
    * annotated.
    *
-   * @param bucket the pre-existing bucket whose annotations to validate
-   * @throws InvalidAnnotationException if not annotated properly
+   * @param bucket the pre-existing bucket whose annotations to validate.
+   * @throws InvalidAnnotationException if not annotated properly.
+   * @return The bucket that was validated.
    */
   protected abstract Bucket checkBucket(Bucket bucket) throws InvalidAnnotationException;
 

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractBucketLifecycleManager.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractBucketLifecycleManager.java
@@ -155,9 +155,7 @@ public abstract class AbstractBucketLifecycleManager extends AbstractUpload {
    */
   protected abstract Bucket decorateBucket(Bucket bucket);
 
-  /**
-   * Boilerplate, see: https://wiki.jenkins-ci.org/display/JENKINS/Defining+a+new+extension+point
-   */
+  /** {@inheritDoc} */
   public AbstractBucketLifecycleManagerDescriptor getDescriptor() {
     return (AbstractBucketLifecycleManagerDescriptor)
         checkNotNull(Hudson.getInstance()).getDescriptor(getClass());

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractBucketLifecycleManager.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractBucketLifecycleManager.java
@@ -55,7 +55,6 @@ import javax.annotation.Nullable;
  * @see com.google.jenkins.plugins.storage.ExpiringBucketLifecycleManager
  */
 public abstract class AbstractBucketLifecycleManager extends AbstractUpload {
-  /** Constructs the base bucket OLM plugin from the bucket name and module. */
   /**
    * Constructs the base bucket OLM plugin from the bucket name and module.
    *

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractBucketLifecycleManager.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractBucketLifecycleManager.java
@@ -56,6 +56,12 @@ import javax.annotation.Nullable;
  */
 public abstract class AbstractBucketLifecycleManager extends AbstractUpload {
   /** Constructs the base bucket OLM plugin from the bucket name and module. */
+  /**
+   * Constructs the base bucket OLM plugin from the bucket name and module.
+   *
+   * @param bucket GCS Bucket in which to alter the time to live.
+   * @param module Helper class methods to use for execution.
+   */
   public AbstractBucketLifecycleManager(String bucket, @Nullable UploadModule module) {
     super(bucket, module);
   }

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractBucketLifecycleManager.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractBucketLifecycleManager.java
@@ -151,7 +151,7 @@ public abstract class AbstractBucketLifecycleManager extends AbstractUpload {
   /**
    * A hook by which extensions may annotate a new or existing bucket.
    *
-   * @param bucket the bucket to annotate and return
+   * @return bucket the bucket to annotate and return
    */
   protected abstract Bucket decorateBucket(Bucket bucket);
 

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractBucketLifecycleManager.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractBucketLifecycleManager.java
@@ -157,7 +157,8 @@ public abstract class AbstractBucketLifecycleManager extends AbstractUpload {
   /**
    * A hook by which extensions may annotate a new or existing bucket.
    *
-   * @return bucket the bucket to annotate and return
+   * @param bucket The bucket to annotate and return.
+   * @return The bucket to annotate and return.
    */
   protected abstract Bucket decorateBucket(Bucket bucket);
 

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
@@ -101,10 +101,8 @@ public abstract class AbstractUpload
           "svg", "image/svg+xml",
           "woff2", "font/woff2");
   private String pathPrefix;
-  /** The module to use for providing dependencies. */
+  // The module to use for providing dependencies.
   protected final transient UploadModule module;
-  /** @return Provide detail information summarizing this download for the GCS upload report. */
-  public abstract String getDetails();
   // NOTE: old name kept for deserialization
   private final String bucketNameWithVars;
   private boolean sharedPublicly;
@@ -268,6 +266,9 @@ public abstract class AbstractUpload
     // else NOT_BUILT
     return false;
   }
+
+  /** @return Provide detail information summarizing this download for the GCS upload report. */
+  public abstract String getDetails();
 
   /**
    * @return The bucket name specified by the user, which potentially contains unresolved symbols,

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
@@ -103,7 +103,7 @@ public abstract class AbstractUpload
   private String pathPrefix;
   /** The module to use for providing dependencies. */
   protected final transient UploadModule module;
-  /** Provide detail information summarizing this download for the GCS upload report. */
+  /** @return Provide detail information summarizing this download for the GCS upload report. */
   public abstract String getDetails();
   // NOTE: old name kept for deserialization
   private final String bucketNameWithVars;
@@ -208,6 +208,11 @@ public abstract class AbstractUpload
    * core logic should upload.
    *
    * @see UploadSpec for further details.
+   * @param run Current job being run.
+   * @param workspace Workspace of node running the job.
+   * @param listener Listener for events of this job.
+   * @return Set of {@link FilePath}s to upload.
+   * @throws UploadException If there was an issue fetching the inclusions.
    */
   @Nullable
   protected abstract UploadSpec getInclusions(
@@ -219,6 +224,9 @@ public abstract class AbstractUpload
    *
    * <p>NOTE: The base implementation does not do anything, so calling {@code
    * super.annotateObject()} is unnecessary.
+   * @param object GCS object to annotate.
+   * @param listener Listener for events of this job.
+   * @throws UploadException If there was an issue annotating the object with metadata.
    */
   protected void annotateObject(StorageObject object, TaskListener listener)
       throws UploadException {
@@ -229,6 +237,8 @@ public abstract class AbstractUpload
    * Retrieves the metadata to attach to the storage object.
    *
    * <p>NOTE: This can be overriden to surface additional (or less) information.
+   * @param run Current job being run.
+   * @return Metadata in key-value form.
    */
   protected Map<String, String> getMetadata(Run<?, ?> run) {
     return MetadataContainer.of(run).getSerializedMetadata();
@@ -587,7 +597,9 @@ public abstract class AbstractUpload
    * Fetches or creates an instance of the bucket with the given name with the specified storage
    * service.
    *
+   * @param service Handle to the GCS API.
    * @param credentials The credentials with which to fetch/create the bucket
+   * @param executor Helper class to make calls to the GCS API.
    * @param bucketName The top-level bucket name to ensure exists
    * @return an instance of the named bucket, created or retrieved.
    * @throws UploadException if any issues are encountered

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
@@ -203,7 +203,6 @@ public abstract class AbstractUpload
     public final Collection<FilePath> inclusions;
   }
 
-  //TODO: Return an optional for UploadSpec?
   /**
    * Implementations override this interface in order to surface the set of {@link FilePath}s the
    * core logic should upload.

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
@@ -203,6 +203,7 @@ public abstract class AbstractUpload
     public final Collection<FilePath> inclusions;
   }
 
+  //TODO: Return an optional for UploadSpec?
   /**
    * Implementations override this interface in order to surface the set of {@link FilePath}s the
    * core logic should upload.

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
@@ -224,6 +224,7 @@ public abstract class AbstractUpload
    *
    * <p>NOTE: The base implementation does not do anything, so calling {@code
    * super.annotateObject()} is unnecessary.
+   *
    * @param object GCS object to annotate.
    * @param listener Listener for events of this job.
    * @throws UploadException If there was an issue annotating the object with metadata.
@@ -237,6 +238,7 @@ public abstract class AbstractUpload
    * Retrieves the metadata to attach to the storage object.
    *
    * <p>NOTE: This can be overriden to surface additional (or less) information.
+   *
    * @param run Current job being run.
    * @return Metadata in key-value form.
    */

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractUploadDescriptor.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractUploadDescriptor.java
@@ -58,8 +58,7 @@ public abstract class AbstractUploadDescriptor extends Descriptor<AbstractUpload
   private final UploadModule module;
 
   /** This callback validates the {@code bucketNameWithVars} input field's values. */
-  public static FormValidation staticDoCheckBucket(final String bucketNameWithVars)
-      throws IOException {
+  public static FormValidation staticDoCheckBucket(final String bucketNameWithVars) {
     String resolvedInput = Resolve.resolveBuiltin(bucketNameWithVars);
     if (!resolvedInput.startsWith(GCS_SCHEME)) {
       return FormValidation.error(

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractUploadDescriptor.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractUploadDescriptor.java
@@ -31,6 +31,7 @@ public abstract class AbstractUploadDescriptor extends Descriptor<AbstractUpload
   /**
    * Create the descriptor of the Upload from it's type on associated module for instantiating
    * dependencies.
+   *
    * @param clazz Class that extends {@link AbstractUpload}.
    * @param module Helper class methods to use for execution.
    */
@@ -41,6 +42,7 @@ public abstract class AbstractUploadDescriptor extends Descriptor<AbstractUpload
 
   /**
    * Create the descriptor of the Upload from it's type of {@link AbstractUpload}.
+   *
    * @param clazz Class that extends {@link AbstractUpload}.
    */
   protected AbstractUploadDescriptor(Class<? extends AbstractUpload> clazz) {
@@ -48,8 +50,8 @@ public abstract class AbstractUploadDescriptor extends Descriptor<AbstractUpload
   }
 
   /**
-   * @return Retrieve the module to use for instantiating dependencies for instances described by this
-   * descriptor.
+   * @return Retrieve the module to use for instantiating dependencies for instances described by
+   *     this descriptor.
    */
   public UploadModule getModule() {
     return module;

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractUploadDescriptor.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractUploadDescriptor.java
@@ -27,6 +27,9 @@ import org.kohsuke.stapler.StaplerRequest;
 
 /** Descriptor from which Upload extensions must derive their descriptor. */
 public abstract class AbstractUploadDescriptor extends Descriptor<AbstractUpload> {
+  // The URI "scheme" that prefixes GCS URIs
+  public static final String GCS_SCHEME = "gs://";
+  private final UploadModule module;
 
   /**
    * Create the descriptor of the Upload from it's type on associated module for instantiating
@@ -57,9 +60,12 @@ public abstract class AbstractUploadDescriptor extends Descriptor<AbstractUpload
     return module;
   }
 
-  private final UploadModule module;
-
-  /** This callback validates the {@code bucketNameWithVars} input field's values. */
+  /**
+   * This callback validates the {@code bucketNameWithVars} input field's values.
+   *
+   * @param bucketNameWithVars GCS bucket.
+   * @return Valid form validation result or error message if invalid.
+   */
   public static FormValidation staticDoCheckBucket(final String bucketNameWithVars) {
     String resolvedInput = Resolve.resolveBuiltin(bucketNameWithVars);
     if (!resolvedInput.startsWith(GCS_SCHEME)) {
@@ -89,6 +95,13 @@ public abstract class AbstractUploadDescriptor extends Descriptor<AbstractUpload
     return FormValidation.ok();
   }
 
+  /**
+   * This callback validates the {@code bucketNameWithVars} input field's values.
+   *
+   * @param bucketNameWithVars GCS bucket.
+   * @return Valid form validation result or error message if invalid.
+   * @throws IOException If there was in issue validating the bucket.
+   */
   public FormValidation doCheckBucketNameWithVars(@QueryParameter final String bucketNameWithVars)
       throws IOException {
     return staticDoCheckBucket(bucketNameWithVars);
@@ -105,6 +118,7 @@ public abstract class AbstractUploadDescriptor extends Descriptor<AbstractUpload
     return staticDoCheckBucket(bucket);
   }
 
+  /** {@inheritDoc} */
   @Override
   public AbstractUpload newInstance(StaplerRequest req, JSONObject formData) throws FormException {
     // Since the config form lists the optional parameter pathPrefix as inline,
@@ -117,7 +131,4 @@ public abstract class AbstractUploadDescriptor extends Descriptor<AbstractUpload
     }
     return super.newInstance(req, formData);
   }
-
-  /** The URI "scheme" that prefixes GCS URIs */
-  public static final String GCS_SCHEME = "gs://";
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractUploadDescriptor.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractUploadDescriptor.java
@@ -31,6 +31,8 @@ public abstract class AbstractUploadDescriptor extends Descriptor<AbstractUpload
   /**
    * Create the descriptor of the Upload from it's type on associated module for instantiating
    * dependencies.
+   * @param clazz Class that extends {@link AbstractUpload}.
+   * @param module Helper class methods to use for execution.
    */
   protected AbstractUploadDescriptor(Class<? extends AbstractUpload> clazz, UploadModule module) {
     super(checkNotNull(clazz));
@@ -38,14 +40,15 @@ public abstract class AbstractUploadDescriptor extends Descriptor<AbstractUpload
   }
 
   /**
-   * Boilerplate, see: https://wiki.jenkins-ci.org/display/JENKINS/Defining+a+new+extension+point
+   * Create the descriptor of the Upload from it's type of {@link AbstractUpload}.
+   * @param clazz Class that extends {@link AbstractUpload}.
    */
   protected AbstractUploadDescriptor(Class<? extends AbstractUpload> clazz) {
     this(checkNotNull(clazz), new UploadModule());
   }
 
   /**
-   * Retrieve the module to use for instantiating dependencies for instances described by this
+   * @return Retrieve the module to use for instantiating dependencies for instances described by this
    * descriptor.
    */
   public UploadModule getModule() {
@@ -90,6 +93,13 @@ public abstract class AbstractUploadDescriptor extends Descriptor<AbstractUpload
     return staticDoCheckBucket(bucketNameWithVars);
   }
 
+  /**
+   * Form validation for bucket parameter.
+   *
+   * @param bucket GCS bucket.
+   * @return Valid form validation result or error message if invalid.
+   * @throws IOException If there was an issue validating the bucket.
+   */
   public FormValidation doCheckBucket(@QueryParameter final String bucket) throws IOException {
     return staticDoCheckBucket(bucket);
   }

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractUploadDescriptor.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractUploadDescriptor.java
@@ -100,7 +100,7 @@ public abstract class AbstractUploadDescriptor extends Descriptor<AbstractUpload
    *
    * @param bucketNameWithVars GCS bucket.
    * @return Valid form validation result or error message if invalid.
-   * @throws IOException If there was in issue validating the bucket.
+   * @throws IOException If there was an issue validating the bucket.
    */
   public FormValidation doCheckBucketNameWithVars(@QueryParameter final String bucketNameWithVars)
       throws IOException {

--- a/src/main/java/com/google/jenkins/plugins/storage/ClassicUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/ClassicUpload.java
@@ -39,6 +39,13 @@ public class ClassicUpload extends AbstractUpload {
   /**
    * Construct the classic upload implementation from the base properties and the glob for matching
    * files.
+   *
+   * @param bucket GCS bucket to upload files to.
+   * @param module Helper class for connecting to the GCS API.
+   * @param pattern The glob of files to upload, which potentially contains unresolved symbols, such
+   *     as $JOB_NAME and $BUILD_NUMBER.
+   * @param bucketNameWithVars Deprecated format for bucket.
+   * @param sourceGlobWithVars Deprecated. Old name kept for deserialization.
    */
   @DataBoundConstructor
   public ClassicUpload(
@@ -113,7 +120,7 @@ public class ClassicUpload extends AbstractUpload {
   }
 
   /**
-   * The glob of files to upload, which potentially contains unresolved symbols, such as $JOB_NAME
+   * @return The glob of files to upload, which potentially contains unresolved symbols, such as $JOB_NAME
    * and $BUILD_NUMBER.
    */
   public String getPattern() {
@@ -141,9 +148,14 @@ public class ClassicUpload extends AbstractUpload {
       return Messages.ClassicUpload_DisplayName();
     }
 
-    /** This callback validates the {@code pattern} input field's values. */
-    public static FormValidation staticDoCheckPattern(@QueryParameter final String pattern)
-        throws IOException {
+    /**
+     * This callback validates the {@code pattern} input field's values.
+     *
+     * @param pattern The glob of files to upload, which potentially contains unresolved symbols, such
+     *     as $JOB_NAME and $BUILD_NUMBER.
+     * @return Valid form validation result or error message if invalid.
+     */
+    public static FormValidation staticDoCheckPattern(@QueryParameter final String pattern) {
       String resolvedInput = Resolve.resolveBuiltin(pattern);
       if (resolvedInput.isEmpty()) {
         return FormValidation.error(Messages.ClassicUpload_EmptyGlob());
@@ -168,8 +180,14 @@ public class ClassicUpload extends AbstractUpload {
       return FormValidation.ok();
     }
 
-    /** This callback validates the {@code pattern} input field's values. */
-    public FormValidation doCheckPattern(@QueryParameter final String pattern) throws IOException {
+    /**
+     * This callback validates the {@code pattern} input field's values.
+     *
+     * @param pattern The glob of files to upload, which potentially contains unresolved symbols, such
+     *     as $JOB_NAME and $BUILD_NUMBER.
+     * @return Valid form validation result or error message if invalid.
+     */
+    public FormValidation doCheckPattern(@QueryParameter final String pattern) {
       return staticDoCheckPattern(pattern);
     }
   }

--- a/src/main/java/com/google/jenkins/plugins/storage/ClassicUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/ClassicUpload.java
@@ -120,8 +120,8 @@ public class ClassicUpload extends AbstractUpload {
   }
 
   /**
-   * @return The glob of files to upload, which potentially contains unresolved symbols, such as $JOB_NAME
-   * and $BUILD_NUMBER.
+   * @return The glob of files to upload, which potentially contains unresolved symbols, such as
+   *     $JOB_NAME and $BUILD_NUMBER.
    */
   public String getPattern() {
     return sourceGlobWithVars;
@@ -151,8 +151,8 @@ public class ClassicUpload extends AbstractUpload {
     /**
      * This callback validates the {@code pattern} input field's values.
      *
-     * @param pattern The glob of files to upload, which potentially contains unresolved symbols, such
-     *     as $JOB_NAME and $BUILD_NUMBER.
+     * @param pattern The glob of files to upload, which potentially contains unresolved symbols,
+     *     such as $JOB_NAME and $BUILD_NUMBER.
      * @return Valid form validation result or error message if invalid.
      */
     public static FormValidation staticDoCheckPattern(@QueryParameter final String pattern) {
@@ -183,8 +183,8 @@ public class ClassicUpload extends AbstractUpload {
     /**
      * This callback validates the {@code pattern} input field's values.
      *
-     * @param pattern The glob of files to upload, which potentially contains unresolved symbols, such
-     *     as $JOB_NAME and $BUILD_NUMBER.
+     * @param pattern The glob of files to upload, which potentially contains unresolved symbols,
+     *     such as $JOB_NAME and $BUILD_NUMBER.
      * @return Valid form validation result or error message if invalid.
      */
     public FormValidation doCheckPattern(@QueryParameter final String pattern) {

--- a/src/main/java/com/google/jenkins/plugins/storage/ClassicUploadStep.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/ClassicUploadStep.java
@@ -217,14 +217,23 @@ public class ClassicUploadStep extends Builder implements SimpleBuildStep, Seria
       return super.newInstance(req, formData);
     }
 
-    /** This callback validates the {@code bucketNameWithVars} input field's values. */
-    public FormValidation doCheckBucket(@QueryParameter final String bucket) throws IOException {
+    /**
+     * This callback validates the {@code bucket} input field's values.
+     *
+     * @param bucket GCS bucket to upload files to.
+     * @return Valid form validation result or error message if invalid.
+     */
+    public FormValidation doCheckBucket(@QueryParameter final String bucket) {
       return ClassicUpload.DescriptorImpl.staticDoCheckBucket(bucket);
     }
 
-    /** This callback validates the {@code pattern} input field's values. */
-    public static FormValidation doCheckPattern(@QueryParameter final String pattern)
-        throws IOException {
+    /**
+     * This callback validates the {@code pattern} input field's values.
+     *
+     * @param pattern GCS bucket to upload files to.
+     * @return Valid form validation result or error message if invalid.
+     */
+    public static FormValidation doCheckPattern(@QueryParameter final String pattern) {
       return ClassicUpload.DescriptorImpl.staticDoCheckPattern(pattern);
     }
   }

--- a/src/main/java/com/google/jenkins/plugins/storage/DownloadStep.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/DownloadStep.java
@@ -163,7 +163,7 @@ public class DownloadStep extends Builder implements SimpleBuildStep, Serializab
     return GoogleRobotCredentials.getById(getCredentialsId());
   }
 
-  /** @{inheritDoc} */
+  /** {@inheritDoc} */
   @Override
   public BuildStepMonitor getRequiredMonitorService() {
     return BuildStepMonitor.NONE;
@@ -349,7 +349,7 @@ public class DownloadStep extends Builder implements SimpleBuildStep, Serializab
    *
    * @param uri URI supplied to be split.
    * @return URI split by "*" wildcard.
-   * @throws AbortException
+   * @throws AbortException If there is more than one wild card character in the provided string.
    */
   public static String[] split(String uri) throws AbortException {
     int occurs = StringUtils.countMatches(uri, "*");
@@ -486,9 +486,13 @@ public class DownloadStep extends Builder implements SimpleBuildStep, Serializab
       return super.newInstance(req, formData);
     }
 
-    /** This callback validates the {@code bucketNameWithVars} input field's values. */
-    public FormValidation doCheckBucketUri(@QueryParameter final String bucketUri)
-        throws IOException {
+    /**
+     * This callback validates the {@code bucketNameWithVars} input field's values.
+     *
+     * @param bucketUri Name of the GCS bucket. e.g. gs://MY_BUCKET_NAME
+     * @return Valid form validation result or error message if invalid.
+     */
+    public FormValidation doCheckBucketUri(@QueryParameter final String bucketUri) {
       try {
         BucketPath path = new BucketPath(bucketUri);
         verifySupported(path);

--- a/src/main/java/com/google/jenkins/plugins/storage/ExpiringBucketLifecycleManager.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/ExpiringBucketLifecycleManager.java
@@ -33,7 +33,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class ExpiringBucketLifecycleManager extends AbstractBucketLifecycleManager {
   private static final Logger logger =
       Logger.getLogger(ExpiringBucketLifecycleManager.class.getName());
-  /** NOTE: old name kept for deserialization */
+  // NOTE: old name kept for deserialization
   private final int bucketObjectTTL;
 
   private static final String DELETE = "Delete";

--- a/src/main/java/com/google/jenkins/plugins/storage/ExpiringBucketLifecycleManager.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/ExpiringBucketLifecycleManager.java
@@ -33,8 +33,19 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class ExpiringBucketLifecycleManager extends AbstractBucketLifecycleManager {
   private static final Logger logger =
       Logger.getLogger(ExpiringBucketLifecycleManager.class.getName());
+  /** NOTE: old name kept for deserialization */
+  private final int bucketObjectTTL;
+  private static final String DELETE = "Delete";
 
-  /** Construct the simple lifecycle manager from a TLL and the common properties. */
+  /**
+   * Construct the simple lifecycle manager from a TLL and the common properties.
+   *
+   * @param bucket GCS Bucket in which to alter the time to live.
+   * @param module Helper class methods to use for execution.
+   * @param ttl The number of days after which to delete data stored in the GCS bucket.
+   * @param bucketNameWithVars Legacy name for bucket. Deprecated.
+   * @param bucketObjectTTL Legacy name for ttl. Deprecated.
+   */
   @DataBoundConstructor
   public ExpiringBucketLifecycleManager(
       String bucket,
@@ -123,14 +134,10 @@ public class ExpiringBucketLifecycleManager extends AbstractBucketLifecycleManag
     return bucket;
   }
 
-  /** Surface the TTL for objects contained within the bucket for roundtripping to the jelly UI. */
+  /** @return Surface the TTL for objects contained within the bucket for roundtripping to the jelly UI. */
   public int getTtl() {
     return bucketObjectTTL;
   }
-  /** NOTE: old name kept for deserialization */
-  private final int bucketObjectTTL;
-
-  private static final String DELETE = "Delete";
 
   /** Denotes this is an {@link AbstractUpload} plugin */
   @Extension

--- a/src/main/java/com/google/jenkins/plugins/storage/ExpiringBucketLifecycleManager.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/ExpiringBucketLifecycleManager.java
@@ -35,6 +35,7 @@ public class ExpiringBucketLifecycleManager extends AbstractBucketLifecycleManag
       Logger.getLogger(ExpiringBucketLifecycleManager.class.getName());
   /** NOTE: old name kept for deserialization */
   private final int bucketObjectTTL;
+
   private static final String DELETE = "Delete";
 
   /**
@@ -134,7 +135,10 @@ public class ExpiringBucketLifecycleManager extends AbstractBucketLifecycleManag
     return bucket;
   }
 
-  /** @return Surface the TTL for objects contained within the bucket for roundtripping to the jelly UI. */
+  /**
+   * @return Surface the TTL for objects contained within the bucket for roundtripping to the jelly
+   *     UI.
+   */
   public int getTtl() {
     return bucketObjectTTL;
   }

--- a/src/main/java/com/google/jenkins/plugins/storage/ExpiringBucketLifecycleManagerStep.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/ExpiringBucketLifecycleManagerStep.java
@@ -121,7 +121,14 @@ public class ExpiringBucketLifecycleManagerStep extends Recorder
       return true;
     }
 
-    /** This callback validates the {@code bucket} input field's values. */
+
+     /**
+     * This callback validates the {@code bucket} input field's values.
+     *
+     * @param bucket GCS Bucket in which to alter the time to live.
+     * @return Valid form validation result or error message if invalid.
+     * @throws IOException If there was an issue validating the bucket provided.
+     */
     public FormValidation doCheckBucket(@QueryParameter final String bucket) throws IOException {
       return ExpiringBucketLifecycleManager.DescriptorImpl.staticDoCheckBucket(bucket);
     }

--- a/src/main/java/com/google/jenkins/plugins/storage/ExpiringBucketLifecycleManagerStep.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/ExpiringBucketLifecycleManagerStep.java
@@ -121,8 +121,7 @@ public class ExpiringBucketLifecycleManagerStep extends Recorder
       return true;
     }
 
-
-     /**
+    /**
      * This callback validates the {@code bucket} input field's values.
      *
      * @param bucket GCS Bucket in which to alter the time to live.

--- a/src/main/java/com/google/jenkins/plugins/storage/GoogleCloudStorageUploader.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/GoogleCloudStorageUploader.java
@@ -44,6 +44,8 @@ import org.kohsuke.stapler.DataBoundConstructor;
 /** A Jenkins plugin for uploading files to Google Cloud Storage (GCS). */
 @RequiresDomain(value = StorageScopeRequirement.class)
 public class GoogleCloudStorageUploader extends Recorder {
+  private final String credentialsId;
+  private final List<AbstractUpload> uploads;
 
   /**
    * Construct the GCS uploader to use the provided credentials to upload build artifacts.
@@ -62,24 +64,20 @@ public class GoogleCloudStorageUploader extends Recorder {
     }
   }
 
-  /** The unique ID for the credentials we are using to authenticate with GCS. */
+  /** @return The unique ID for the credentials we are using to authenticate with GCS. */
   public String getCredentialsId() {
     return credentialsId;
   }
 
-  private final String credentialsId;
-
-  /** The credentials we are using to authenticate with GCS. */
+  /** @return The credentials we are using to authenticate with GCS. */
   public GoogleRobotCredentials getCredentials() {
     return GoogleRobotCredentials.getById(getCredentialsId());
   }
 
-  /** The set of tuples describing the artifacts to upload, and where to upload them. */
+  /** @return The set of tuples describing the artifacts to upload, and where to upload them. */
   public Collection<AbstractUpload> getUploads() {
     return Collections.unmodifiableCollection(uploads);
   }
-
-  private final List<AbstractUpload> uploads;
 
   /** {@inheritDoc} */
   @Override
@@ -145,6 +143,7 @@ public class GoogleCloudStorageUploader extends Recorder {
       return ImmutableList.<AbstractUpload>of(upload);
     }
 
+    /** @return All registered {@link AbstractUpload}s. */
     public List<AbstractUploadDescriptor> getUploads() {
       return AbstractUpload.all();
     }

--- a/src/main/java/com/google/jenkins/plugins/storage/HttpHeaders.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/HttpHeaders.java
@@ -23,6 +23,7 @@ public class HttpHeaders {
 
   /**
    * Returns an RFC 6266 Content-Disposition header for the given filename.
+   *
    * @param filename Name of the file to get the Content-Disposition header for.
    * @param showInline If the content should be displayed inline or as an attachment.
    * @return The RFC 6266 Content-Disposition header for the filename.

--- a/src/main/java/com/google/jenkins/plugins/storage/HttpHeaders.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/HttpHeaders.java
@@ -21,6 +21,12 @@ import com.google.common.base.Charsets;
 public class HttpHeaders {
 
   /** Returns an RFC 6266 Content-Disposition header for the given filename. */
+  /**
+   *
+   * @param filename Name of the file to get the Content-Disposition header for.
+   * @param showInline
+   * @return
+   */
   public static String getContentDisposition(String filename, boolean showInline) {
     return String.format(
         "%s; filename=%s; filename*=%s",

--- a/src/main/java/com/google/jenkins/plugins/storage/HttpHeaders.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/HttpHeaders.java
@@ -19,13 +19,13 @@ import com.google.common.base.Charsets;
 
 /** Utility class for building HTTP header values. */
 public class HttpHeaders {
+  private static final String RFC_5987_ATTR_CHARS = "!#$&+-.^_`|~";
 
-  /** Returns an RFC 6266 Content-Disposition header for the given filename. */
   /**
-   *
+   * Returns an RFC 6266 Content-Disposition header for the given filename.
    * @param filename Name of the file to get the Content-Disposition header for.
-   * @param showInline
-   * @return
+   * @param showInline If the content should be displayed inline or as an attachment.
+   * @return The RFC 6266 Content-Disposition header for the filename.
    */
   public static String getContentDisposition(String filename, boolean showInline) {
     return String.format(
@@ -81,8 +81,6 @@ public class HttpHeaders {
     }
     return builder.toString();
   }
-
-  private static final String RFC_5987_ATTR_CHARS = "!#$&+-.^_`|~";
 
   private HttpHeaders() {}
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/InvalidAnnotationException.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/InvalidAnnotationException.java
@@ -24,11 +24,15 @@ import com.google.api.services.storage.model.Bucket;
  * AbstractBucketLifecycleManager#checkBucket} when a bucket is not properly annotated.
  */
 public class InvalidAnnotationException extends Exception {
+  /**
+   * Constructor for the exception.
+   * @param bucket Name of the GCS bucket.
+   */
   public InvalidAnnotationException(Bucket bucket) {
     this.bucket = checkNotNull(bucket);
   }
 
-  /** The bucket that isn't properly annotated. */
+  /** @return The bucket that isn't properly annotated. */
   public Bucket getBucket() {
     return this.bucket;
   }

--- a/src/main/java/com/google/jenkins/plugins/storage/InvalidAnnotationException.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/InvalidAnnotationException.java
@@ -26,6 +26,7 @@ import com.google.api.services.storage.model.Bucket;
 public class InvalidAnnotationException extends Exception {
   /**
    * Constructor for the exception.
+   *
    * @param bucket Name of the GCS bucket.
    */
   public InvalidAnnotationException(Bucket bucket) {

--- a/src/main/java/com/google/jenkins/plugins/storage/StdoutUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/StdoutUpload.java
@@ -42,10 +42,15 @@ import org.kohsuke.stapler.QueryParameter;
  * bucket, with a specified file name. By default, the file is named "build-log.txt".
  */
 public class StdoutUpload extends AbstractUpload {
+  private final String logName;
 
   /**
    * Construct the Upload with the stock properties, and the additional information about how to
    * name the build log file.
+   * @param bucket GCS bucket to upload build artifacts to.
+   * @param module An {@link UploadModule} to use for execution.
+   * @param logName Name of log file to store to GCS bucket.
+   * @param bucketNameWithVars Deprecated format for bucket.
    */
   @DataBoundConstructor
   public StdoutUpload(
@@ -58,12 +63,10 @@ public class StdoutUpload extends AbstractUpload {
     this.logName = checkNotNull(logName);
   }
 
-  /** The name to give the file we upload for the build log. */
+  /** @return The name to give the file we upload for the build log. */
   public String getLogName() {
     return logName;
   }
-
-  private final String logName;
 
   /** {@inheritDoc} */
   @Override
@@ -132,8 +135,13 @@ public class StdoutUpload extends AbstractUpload {
       return Messages.StdoutUpload_DisplayName();
     }
 
-    /** This callback validates the {@code logName} input field's values. */
-    public FormValidation doCheckLogName(@QueryParameter final String logName) throws IOException {
+    /**
+     * This callback validates the {@code logName} input field's values.
+     *
+     * @param logName Name for the build log that will be uploaded to the GCS bucket.
+     * @return Valid form validation result or error message if invalid.
+     */
+    public FormValidation doCheckLogName(@QueryParameter final String logName) {
       String resolvedInput = Resolve.resolveBuiltin(logName);
       if (resolvedInput.isEmpty()) {
         return FormValidation.error(Messages.StdoutUpload_LogNameRequired());

--- a/src/main/java/com/google/jenkins/plugins/storage/StdoutUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/StdoutUpload.java
@@ -47,6 +47,7 @@ public class StdoutUpload extends AbstractUpload {
   /**
    * Construct the Upload with the stock properties, and the additional information about how to
    * name the build log file.
+   *
    * @param bucket GCS bucket to upload build artifacts to.
    * @param module An {@link UploadModule} to use for execution.
    * @param logName Name of log file to store to GCS bucket.

--- a/src/main/java/com/google/jenkins/plugins/storage/StdoutUploadStep.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/StdoutUploadStep.java
@@ -73,14 +73,16 @@ public class StdoutUploadStep extends Recorder implements SimpleBuildStep, Seria
   }
 
   /**
-   * @param sharedPublicly Whether to indicate in metadata that the file should be viewable inline
-   *     in web browsers, rather than requiring it to be downloaded first.
+   * @param sharedPublicly Whether to surface the file being uploaded to anyone with the link.
    */
   @DataBoundSetter
   public void setSharedPublicly(boolean sharedPublicly) {
     upload.setSharedPublicly(sharedPublicly);
   }
 
+  /**
+   * @return Whether to surface the file being uploaded to anyone with the link.
+   */
   public boolean isSharedPublicly() {
     return upload.isSharedPublicly();
   }
@@ -94,6 +96,10 @@ public class StdoutUploadStep extends Recorder implements SimpleBuildStep, Seria
     upload.setShowInline(showInline);
   }
 
+  /**
+   * @return Whether to indicate in metadata that the file should be viewable
+   * inline in web browsers, rather than requiring it to be downloaded first.
+   */
   public boolean isShowInline() {
     return upload.isShowInline();
   }
@@ -158,13 +164,22 @@ public class StdoutUploadStep extends Recorder implements SimpleBuildStep, Seria
       return true;
     }
 
-    /** This callback validates the {@code bucket} input field's values. */
-    public FormValidation doCheckBucket(@QueryParameter final String bucket) throws IOException {
+    /**
+     * This callback validates the {@code bucket} input field's values.
+     *
+     * @param bucket GCS bucket to upload build logs to.
+     * @return Valid form validation result or error message if invalid.
+     */    public FormValidation doCheckBucket(@QueryParameter final String bucket) throws IOException {
       return StdoutUpload.DescriptorImpl.staticDoCheckBucket(bucket);
     }
 
-    public static FormValidation doCheckLogName(@QueryParameter final String logName)
-        throws IOException {
+    /**
+     * This callback validates the {@code logName} input field's values.
+     *
+     * @param logName Name for the build log that will be uploaded to the GCS bucket.
+     * @return Valid form validation result or error message if invalid.
+     */
+    public static FormValidation doCheckLogName(@QueryParameter final String logName) {
       return new StdoutUpload.DescriptorImpl().doCheckLogName(logName);
     }
 

--- a/src/main/java/com/google/jenkins/plugins/storage/StdoutUploadStep.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/StdoutUploadStep.java
@@ -166,7 +166,7 @@ public class StdoutUploadStep extends Recorder implements SimpleBuildStep, Seria
      * @param bucket GCS bucket to upload build logs to.
      * @return Valid form validation result or error message if invalid.
      */
-    public FormValidation doCheckBucket(@QueryParameter final String bucket) throws IOException {
+    public FormValidation doCheckBucket(@QueryParameter final String bucket) {
       return StdoutUpload.DescriptorImpl.staticDoCheckBucket(bucket);
     }
 

--- a/src/main/java/com/google/jenkins/plugins/storage/StdoutUploadStep.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/StdoutUploadStep.java
@@ -72,17 +72,13 @@ public class StdoutUploadStep extends Recorder implements SimpleBuildStep, Seria
     upload = new StdoutUpload(bucket, module.orElse(null), logName, null);
   }
 
-  /**
-   * @param sharedPublicly Whether to surface the file being uploaded to anyone with the link.
-   */
+  /** @param sharedPublicly Whether to surface the file being uploaded to anyone with the link. */
   @DataBoundSetter
   public void setSharedPublicly(boolean sharedPublicly) {
     upload.setSharedPublicly(sharedPublicly);
   }
 
-  /**
-   * @return Whether to surface the file being uploaded to anyone with the link.
-   */
+  /** @return Whether to surface the file being uploaded to anyone with the link. */
   public boolean isSharedPublicly() {
     return upload.isSharedPublicly();
   }
@@ -97,8 +93,8 @@ public class StdoutUploadStep extends Recorder implements SimpleBuildStep, Seria
   }
 
   /**
-   * @return Whether to indicate in metadata that the file should be viewable
-   * inline in web browsers, rather than requiring it to be downloaded first.
+   * @return Whether to indicate in metadata that the file should be viewable inline in web
+   *     browsers, rather than requiring it to be downloaded first.
    */
   public boolean isShowInline() {
     return upload.isShowInline();
@@ -169,7 +165,8 @@ public class StdoutUploadStep extends Recorder implements SimpleBuildStep, Seria
      *
      * @param bucket GCS bucket to upload build logs to.
      * @return Valid form validation result or error message if invalid.
-     */    public FormValidation doCheckBucket(@QueryParameter final String bucket) throws IOException {
+     */
+    public FormValidation doCheckBucket(@QueryParameter final String bucket) throws IOException {
       return StdoutUpload.DescriptorImpl.staticDoCheckBucket(bucket);
     }
 

--- a/src/main/java/com/google/jenkins/plugins/storage/client/StorageClient.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/client/StorageClient.java
@@ -74,6 +74,7 @@ public class StorageClient {
    * @param pattern Pattern to match object name to upload to bucket.
    * @param bucket Name of the bucket to upload to.
    * @param content InputStreamContent of desired file to upload.
+   * @return The parsed HTTP response from the request.
    * @throws IOException If there was an issue calling the GCS API.
    */
   public StorageObject uploadToBucket(String pattern, String bucket, InputStreamContent content)

--- a/src/main/java/com/google/jenkins/plugins/storage/util/BucketPath.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/util/BucketPath.java
@@ -22,6 +22,8 @@ import java.io.Serializable;
 
 /** Handles cloud uris and their parsing. */
 public class BucketPath implements Serializable {
+  private final String bucket;
+  private final String object;
 
   /**
    * Prepares a new BucketPath.
@@ -52,32 +54,39 @@ public class BucketPath implements Serializable {
     this.object = (halves.length == 1) ? "" : halves[1];
   }
 
-  /** Initializes BucketPath directly, with no parsing or substitutions. */
+  /**
+   * Initializes BucketPath directly, with no parsing or substitutions.
+   *
+   * @param bucket The bucket portion of the URI.
+   * @param object The path to the object portion of the URI not including bucket.
+   */
   public BucketPath(String bucket, String object) {
     this.bucket = bucket;
     this.object = object;
   }
 
+  /**
+   * Determines if this is an invalid {@link BucketPath}.
+   *
+   * @return False if the bucket is empty.
+   */
   public boolean error() {
     // The bucket cannot be empty under normal circumstances.
     return getBucket().length() <= 0;
   }
 
-  /** Regenerate the path (without gs:// prefix) */
+  /** @return Regenerate the path (without gs:// prefix) */
   public String getPath() {
     return bucket + (object.isEmpty() ? "" : "/" + object);
   }
 
-  /** The Bucket portion of the URI */
+  /** @return The Bucket portion of the URI */
   public String getBucket() {
     return bucket;
   }
 
-  /** The object portion of the URI */
+  /** @return The object portion of the URI */
   public String getObject() {
     return object;
   }
-
-  private final String bucket;
-  private final String object;
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/util/StorageUtil.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/util/StorageUtil.java
@@ -35,7 +35,7 @@ public class StorageUtil {
    * Compute the relative path of the given file inclusion, relative to the given workspace. If the
    * path is absolute, it returns the root-relative path instead.
    *
-   * @param include The file whose relative path we are computing
+   * @param include The file whose relative path we are computing.
    * @param workspace The workspace containing the included file.
    * @return The unix-style relative path of file.
    * @throws UploadException when the input is malformed
@@ -56,6 +56,9 @@ public class StorageUtil {
   /**
    * If a path prefix to strip has been specified, and the input string starts with that prefix,
    * returns the portion of the input after that prefix. Otherwise, returns the unmodified input.
+   * @param filename Input string to strip.
+   * @param pathPrefix Name of the path prefix to strip on.
+   * @return Remaining portion of the input after prefix is stripped.
    */
   public static String getStrippedFilename(String filename, String pathPrefix) {
     if (pathPrefix != null && filename != null && filename.startsWith(pathPrefix)) {
@@ -71,6 +74,8 @@ public class StorageUtil {
    * @param run The current run, used to determine pipeline status and to get environment.
    * @param listener Task listener, used to get environment
    * @return The updated name, with variables resolved
+   * @throws InterruptedException If getting the environment of the run throws an InterruptedException.
+   * @throws IOException If getting the environment of the run throws an IOException.
    */
   public static String replaceMacro(String name, Run<?, ?> run, TaskListener listener)
       throws InterruptedException, IOException {
@@ -84,8 +89,8 @@ public class StorageUtil {
    * Look up credentials by name.
    *
    * @param credentials The name of the credentials to look up.
-   * @return The corresponding {@link GoogleRobotCredentials}
-   * @throws AbortException If credentials not found
+   * @return The corresponding {@link GoogleRobotCredentials}.
+   * @throws AbortException If credentials not found.
    */
   public static GoogleRobotCredentials lookupCredentials(String credentials) throws AbortException {
     GoogleRobotCredentials result = GoogleRobotCredentials.getById(credentials);

--- a/src/main/java/com/google/jenkins/plugins/storage/util/StorageUtil.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/util/StorageUtil.java
@@ -56,6 +56,7 @@ public class StorageUtil {
   /**
    * If a path prefix to strip has been specified, and the input string starts with that prefix,
    * returns the portion of the input after that prefix. Otherwise, returns the unmodified input.
+   *
    * @param filename Input string to strip.
    * @param pathPrefix Name of the path prefix to strip on.
    * @return Remaining portion of the input after prefix is stripped.
@@ -74,7 +75,8 @@ public class StorageUtil {
    * @param run The current run, used to determine pipeline status and to get environment.
    * @param listener Task listener, used to get environment
    * @return The updated name, with variables resolved
-   * @throws InterruptedException If getting the environment of the run throws an InterruptedException.
+   * @throws InterruptedException If getting the environment of the run throws an
+   *     InterruptedException.
    * @throws IOException If getting the environment of the run throws an IOException.
    */
   public static String replaceMacro(String name, Run<?, ?> run, TaskListener listener)


### PR DESCRIPTION
While releasing 1.3.0, the release process detected issues when trying to generate the Java doc.

I have addressed most of the issues (mostly missing params, returns, exceptions) and did some code clean-up.