### PR TITLE
Issue #78 and #82: Avoid using Jenkins when generating UploadModule

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractBucketLifecycleManager.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractBucketLifecycleManager.java
@@ -26,11 +26,11 @@ import com.google.jenkins.plugins.util.Executor;
 import com.google.jenkins.plugins.util.ExecutorException;
 import com.google.jenkins.plugins.util.NotFoundException;
 import hudson.FilePath;
-import hudson.model.Hudson;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.io.IOException;
 import javax.annotation.Nullable;
+import jenkins.model.Jenkins;
 
 /**
  * This extension point may be implemented to surface the object lifecycle options available on
@@ -165,6 +165,6 @@ public abstract class AbstractBucketLifecycleManager extends AbstractUpload {
   /** {@inheritDoc} */
   public AbstractBucketLifecycleManagerDescriptor getDescriptor() {
     return (AbstractBucketLifecycleManagerDescriptor)
-        checkNotNull(Hudson.getInstance()).getDescriptor(getClass());
+        checkNotNull(Jenkins.get()).getDescriptor(getClass());
   }
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
@@ -49,7 +49,6 @@ import hudson.ExtensionPoint;
 import hudson.FilePath;
 import hudson.model.AbstractBuild;
 import hudson.model.Describable;
-import hudson.model.Hudson;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -67,6 +66,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
+import jenkins.model.Jenkins;
 import org.apache.commons.io.FilenameUtils;
 import org.jenkinsci.remoting.RoleChecker;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -120,7 +120,7 @@ public abstract class AbstractUpload
     if (module != null) {
       this.module = module;
     } else {
-      this.module = getDescriptor().getModule();
+      this.module = new UploadModule();
     }
     this.bucketNameWithVars = checkNotNull(bucket);
   }
@@ -273,7 +273,7 @@ public abstract class AbstractUpload
   /** @return The {@link UploadModule} for providing dependencies. */
   protected synchronized UploadModule getModule() {
     if (this.module == null) {
-      return getDescriptor().getModule();
+      return new UploadModule();
     }
     return this.module;
   }
@@ -356,13 +356,12 @@ public abstract class AbstractUpload
    * @return All registered {@link AbstractUpload}s.
    */
   public static DescriptorExtensionList<AbstractUpload, AbstractUploadDescriptor> all() {
-    return checkNotNull(Hudson.getInstance())
-        .<AbstractUpload, AbstractUploadDescriptor>getDescriptorList(AbstractUpload.class);
+    return checkNotNull(Jenkins.get()).getDescriptorList(AbstractUpload.class);
   }
 
   /** {@inheritDoc} */
   public AbstractUploadDescriptor getDescriptor() {
-    return (AbstractUploadDescriptor) checkNotNull(Hudson.getInstance()).getDescriptor(getClass());
+    return (AbstractUploadDescriptor) checkNotNull(Jenkins.get()).getDescriptor(getClass());
   }
 
   /**

--- a/src/main/java/com/google/jenkins/plugins/storage/DownloadStep.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/DownloadStep.java
@@ -35,7 +35,6 @@ import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.AbstractProject;
-import hudson.model.Hudson;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.remoting.Callable;
@@ -54,6 +53,7 @@ import java.util.Queue;
 import java.util.logging.Logger;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
@@ -104,7 +104,7 @@ public class DownloadStep extends Builder implements SimpleBuildStep, Serializab
     if (module != null) {
       this.module = module;
     } else {
-      this.module = getDescriptor().getModule();
+      this.module = new UploadModule();
     }
 
     this.bucketUri = bucketUri;
@@ -156,7 +156,7 @@ public class DownloadStep extends Builder implements SimpleBuildStep, Serializab
   /** @return The UploadModule used for providing dependencies. */
   protected synchronized UploadModule getModule() {
     if (this.module == null) {
-      return getDescriptor().getModule();
+      return new UploadModule();
     }
     return this.module;
   }
@@ -454,7 +454,7 @@ public class DownloadStep extends Builder implements SimpleBuildStep, Serializab
 
   /** {@inheritDoc} */
   public DescriptorImpl getDescriptor() {
-    return (DescriptorImpl) checkNotNull(Hudson.getInstance()).getDescriptor(getClass());
+    return (DescriptorImpl) checkNotNull(Jenkins.get()).getDescriptor(getClass());
   }
 
   /** Descriptor for the DownloadStep */

--- a/src/main/java/com/google/jenkins/plugins/storage/UploadModule.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/UploadModule.java
@@ -58,7 +58,7 @@ public class UploadModule {
   /** @return the version number of this plugin. */
   public String getVersion() {
     String version = "";
-    Plugin plugin = Jenkins.getInstance().getPlugin(PLUGIN_NAME);
+    Plugin plugin = Jenkins.get().getPlugin(PLUGIN_NAME);
     if (plugin != null) {
       version = plugin.getWrapper().getVersion();
     }


### PR DESCRIPTION
See #78 and #82: Remote agents return null for Jenkins.getInstanceOrNull(), so avoid invoking this when generating an UploadModule.

After addressing #71, UploadModule and MockUploadModule will be removed. However, for the time being the current pattern is required for the way the tests are performed and this bugfix shouldn't be blocked on the significant refactoring that would be needed.