### PR TITLE
Format and tidy pom file after release preparation completes.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,6 +222,13 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <configuration>
+          <completionGoals>xml-format:xml-format tidy:pom</completionGoals>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
         <version>2.8</version>


### PR DESCRIPTION
This occurs after the pom file is modified but before being committed by the release plugin and will prevent the back and forth that keeps happening after releases.