### PR TITLE
Correct the field name for the bucket

### DIFF
--- a/src/main/resources/com/google/jenkins/plugins/storage/AbstractBucketLifecycleManager/config.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/storage/AbstractBucketLifecycleManager/config.jelly
@@ -20,7 +20,7 @@
 
   <!-- Allow the user to specify the name of a bucket containing build
   variables to store the uploaded files -->
-  <f:entry title="${%Bucket name}" field="bucketNameWithVars">
+  <f:entry title="${%Bucket name}" field="bucket">
     <f:textbox default="gs://" />
   </f:entry>
 


### PR DESCRIPTION
The bucket was not displayed when we come back on a job configuration page with a post-build step "Google Cloud Storage Plugin" with "Bucket with expiring elements lifecycle" inside.

It seems to be due to https://github.com/jenkinsci/google-storage-plugin/commit/23a6d931e1c3e9d73e054dfb19cf5e5e10a9c376#diff-9094d32642e066b131dea65a10893b49R245 and is not covered by tests.