### PR TITLE
Upgrade to use version 20.0 of guava, 1.25.0 of api client, and 1.21.0 of http client.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,10 @@
     <jenkins.version>2.164.2</jenkins.version>
     <hpi.compatibleSinceVersion>1.5.0</hpi.compatibleSinceVersion>
     <google.api.version>1.25.0</google.api.version>
+    <google.http.version>1.21.0</google.http.version>
     <google.guava.version>20.0</google.guava.version>
     <google-oauth.version>1.0.0-SNAPSHOT</google-oauth.version>
+    <storage.revision>158</storage.revision>
     <java.level>8</java.level>
     <pipeline-model-definition.version>1.3.8</pipeline-model-definition.version>
     <concurrency>5</concurrency>
@@ -126,6 +128,39 @@
       <artifactId>jackson-databind</artifactId>
       <version>${fasterxml.jackson.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.api-client</groupId>
+      <artifactId>google-api-client</artifactId>
+      <version>${google.api.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.http-client</groupId>
+          <artifactId>google-http-client</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client</artifactId>
+      <version>${google.http.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.google.http-client</groupId>
+      <artifactId>google-http-client-jackson2</artifactId>
+      <version>${google.api.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.http-client</groupId>
+          <artifactId>google-http-client</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <!-- com.google.guava -->
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -175,7 +210,7 @@
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-storage</artifactId>
-      <version>v1-rev158-${google.api.version}</version>
+      <version>v1-rev${storage.revision}-${google.api.version}</version>
       <exclusions>
         <exclusion>
           <groupId>com.google.http-client</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
       Lots of boilerplate from: https://wiki.jenkins-ci.org/display/JENKINS/Hosting+Plugins
   -->
   <artifactId>google-storage-plugin</artifactId>
-  <version>1.4.1-SNAPSHOT</version>
+  <version>1.5.0-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Google Cloud Storage plugin</name>
@@ -64,7 +64,10 @@
   <!-- Bring some sanity to version numbering... -->
   <properties>
     <jenkins.version>2.164.2</jenkins.version>
-    <google.api.version>1.24.1</google.api.version>
+    <hpi.compatibleSinceVersion>1.5.0</hpi.compatibleSinceVersion>
+    <google.api.version>1.25.0</google.api.version>
+    <google.guava.version>20.0</google.guava.version>
+    <google-oauth.version>1.0.0-SNAPSHOT</google-oauth.version>
     <java.level>8</java.level>
     <pipeline-model-definition.version>1.3.8</pipeline-model-definition.version>
     <concurrency>5</concurrency>
@@ -127,7 +130,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>14.0.1</version>
+      <version>${google.guava.version}</version>
     </dependency>
     <!-- org.joda.time -->
     <dependency>
@@ -159,7 +162,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>google-oauth-plugin</artifactId>
-      <version>0.9</version>
+      <version>${google-oauth.version}</version>
     </dependency>
     <!-- Metadata dependency -->
     <dependency>
@@ -172,7 +175,13 @@
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-storage</artifactId>
-      <version>v1-rev155-${google.api.version}</version>
+      <version>v1-rev158-${google.api.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.http-client</groupId>
+          <artifactId>google-http-client</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <google.api.version>1.25.0</google.api.version>
     <google.http.version>1.21.0</google.http.version>
     <google.guava.version>20.0</google.guava.version>
-    <google-oauth.version>1.0.0-SNAPSHOT</google-oauth.version>
+    <google-oauth.version>1.0.0</google-oauth.version>
     <storage.revision>158</storage.revision>
     <java.level>8</java.level>
     <pipeline-model-definition.version>1.3.8</pipeline-model-definition.version>

--- a/src/main/java/com/google/jenkins/plugins/storage/ClassicUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/ClassicUpload.java
@@ -15,7 +15,7 @@
  */
 package com.google.jenkins.plugins.storage;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.jenkins.plugins.storage.util.StorageUtil;
 import com.google.jenkins.plugins.util.Resolve;
 import hudson.Extension;
@@ -55,8 +55,8 @@ public class ClassicUpload extends AbstractUpload {
       // Legacy arguments for backwards compatibility
       @Deprecated @Nullable String bucketNameWithVars,
       @Deprecated @Nullable String sourceGlobWithVars) {
-    super(Objects.firstNonNull(bucket, bucketNameWithVars), module);
-    this.sourceGlobWithVars = Objects.firstNonNull(pattern, sourceGlobWithVars);
+    super(MoreObjects.firstNonNull(bucket, bucketNameWithVars), module);
+    this.sourceGlobWithVars = MoreObjects.firstNonNull(pattern, sourceGlobWithVars);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/com/google/jenkins/plugins/storage/ExpiringBucketLifecycleManager.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/ExpiringBucketLifecycleManager.java
@@ -18,7 +18,7 @@ package com.google.jenkins.plugins.storage;
 import static java.util.logging.Level.WARNING;
 
 import com.google.api.services.storage.model.Bucket;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.Lists;
 import hudson.Extension;
 import java.util.List;
@@ -55,9 +55,9 @@ public class ExpiringBucketLifecycleManager extends AbstractBucketLifecycleManag
       // Legacy arguments for backwards compatibility
       @Deprecated @Nullable String bucketNameWithVars,
       @Deprecated @Nullable Integer bucketObjectTTL) {
-    super(Objects.firstNonNull(bucket, bucketNameWithVars), module);
+    super(MoreObjects.firstNonNull(bucket, bucketNameWithVars), module);
 
-    this.bucketObjectTTL = Objects.firstNonNull(ttl, bucketObjectTTL);
+    this.bucketObjectTTL = MoreObjects.firstNonNull(ttl, bucketObjectTTL);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/com/google/jenkins/plugins/storage/StdoutUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/StdoutUpload.java
@@ -18,7 +18,7 @@ package com.google.jenkins.plugins.storage;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.io.ByteStreams.copy;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Closeables;
 import com.google.jenkins.plugins.storage.util.StorageUtil;
@@ -60,7 +60,7 @@ public class StdoutUpload extends AbstractUpload {
       String logName,
       // Legacy arguments for backwards compatibility
       @Deprecated @Nullable String bucketNameWithVars) {
-    super(Objects.firstNonNull(bucket, bucketNameWithVars), module);
+    super(MoreObjects.firstNonNull(bucket, bucketNameWithVars), module);
     this.logName = checkNotNull(logName);
   }
 


### PR DESCRIPTION
See jenkinsci/google-oauth-plugin/pull/75 for explanation of version 1.21.0 for http client.

Also some code changes to switch from Objects.firstNonNull to MoreObjects.firstNonNull because the former was removed from guava.

Depends on upstream changes and releases:
- [x] Change: https://github.com/jenkinsci/google-oauth-plugin/pull/75
- [x] Release 1.0.0 of google-oauth-plugin
- [x] https://github.com/GoogleCloudPlatform/gcp-plugin-core-java/pull/9
- [x] Release 0.2.0 of gcp-plugin-core-java
