### PR TITLE
Removed integrations tests execution by default

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,21 +24,18 @@ pipeline {
 
     stages {
         stage("Build and test") {
-	    agent {
-    	    	kubernetes {
-      		    cloud 'kubernetes'
-      		    label 'maven-pod'
-      		    yamlFile 'jenkins/maven-pod.yaml'
-		}
-	    }
-	    steps {
-	    	container('maven') {
+            agent {
+                kubernetes {
+                    cloud 'kubernetes'
+                    label 'maven-pod'
+                    yamlFile 'jenkins/maven-pod.yaml'
+                }
+            }
+            steps {
+                container('maven') {
                     withCredentials([[$class: 'StringBinding', credentialsId: env.GCS_IT_CRED_ID, variable: 'GOOGLE_CREDENTIALS']]) {
-		        // build
-	    	        sh "mvn clean package -ntp"
-
-		        // run tests
-		        sh "mvn verify -ntp"
+                        // build
+                        sh "mvn verify -ntp -DskipIts=false"
                     }
                 }
             }

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
     <java.level>8</java.level>
     <pipeline-model-definition.version>1.3.8</pipeline-model-definition.version>
     <concurrency>5</concurrency>
+    <skipIts>true</skipIts>
     <fasterxml.jackson.version>2.10.0</fasterxml.jackson.version>
   </properties>
 
@@ -334,6 +335,7 @@
           </execution>
         </executions>
         <configuration>
+          <skipITs>${skipIts}</skipITs>
           <disableXmlReport>true</disableXmlReport>
           <useFile>false</useFile>
         </configuration>


### PR DESCRIPTION
The current integration tests require a specific google infra to be
available. Preventing them to be executed by default prevents false
failure to happen.

In Maven lifecycle, verify comes after package. Executing one shell with
package and another one with verify re-execute unit-tests for nothing.
Finxing this by calling only once verify phase.

cc @craigdbarber @stephenashank 