### PR TITLE
Removed security vulnerability from google-metadata plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,8 +183,7 @@
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <!-- XStream has deserialization warnings for Jodatime 2.0 or later -->
-      <version>2.9.5</version>
+      <version>2.10.5</version>
     </dependency>
     <!-- Test dependencies -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>google-metadata-plugin</artifactId>
-      <version>0.3</version>
+      <version>0.3.1</version>
     </dependency>
     <!-- com.google.apis -->
     <!-- https://developers.google.com/api-client-library/java/apis/storage/v1 -->

--- a/pom.xml
+++ b/pom.xml
@@ -215,7 +215,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>google-metadata-plugin</artifactId>
-      <version>0.2</version>
+      <version>0.3</version>
     </dependency>
     <!-- com.google.apis -->
     <!-- https://developers.google.com/api-client-library/java/apis/storage/v1 -->


### PR DESCRIPTION
Google Metadata plugin 0.2 was using `jackson-databind` with a version subject to a security vulnerability. The 0.3 release of Google Metadata plugin is using `jackson2-api` plugin which is not exposes with this issue.