### PR TITLE
Updated build documentation

### DIFF
--- a/docs/source_build_installation.md
+++ b/docs/source_build_installation.md
@@ -24,7 +24,11 @@
     ```bash      
     git checkout <branch name>
     ```
-1. Build the plugin into a .hpi plugin file:
+1. Build the plugin into a .hpi plugin file. When running a build for the first time, run the clean and package maven goals:
+    ```bash
+    mvn clean package
+    ```
+   Followed by:
     ```bash
     mvn hpi:hpi
     ```


### PR DESCRIPTION
Added instruction for a minor nuance when running a maven build.

Fixes jenkinsci/google-storage-plugin#116