### PR TITLE
Fix ConcurrentModificationException for files actions

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/storage/reports/BuildGcsUploadReport.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/reports/BuildGcsUploadReport.java
@@ -15,7 +15,7 @@
  */
 package com.google.jenkins.plugins.storage.reports;
 
-import com.google.api.client.util.Sets;
+import com.google.common.collect.Sets;
 import com.google.jenkins.plugins.storage.util.BucketPath;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
@@ -35,8 +35,8 @@ public class BuildGcsUploadReport extends AbstractGcsUploadReport {
 
   public BuildGcsUploadReport(Run<?, ?> run) {
     super(run);
-    this.buckets = Sets.newHashSet();
-    this.files = Sets.newHashSet();
+    this.buckets = Sets.newConcurrentHashSet();
+    this.files = Sets.newConcurrentHashSet();
   }
 
   /**

--- a/src/main/java/com/google/jenkins/plugins/storage/reports/BuildGcsUploadReport.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/reports/BuildGcsUploadReport.java
@@ -86,7 +86,9 @@ public class BuildGcsUploadReport extends AbstractGcsUploadReport {
    * @param bucket the directory location in the cloud
    */
   public void addUpload(String relativePath, BucketPath bucket) {
-    files.add(bucket.getPath() + "/" + relativePath);
+    synchronized (files) {
+      files.add(bucket.getPath() + "/" + relativePath);
+    }
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/com/google/jenkins/plugins/storage/reports/BuildGcsUploadReport.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/reports/BuildGcsUploadReport.java
@@ -86,9 +86,7 @@ public class BuildGcsUploadReport extends AbstractGcsUploadReport {
    * @param bucket the directory location in the cloud
    */
   public void addUpload(String relativePath, BucketPath bucket) {
-    synchronized (files) {
-      files.add(bucket.getPath() + "/" + relativePath);
-    }
+    files.add(bucket.getPath() + "/" + relativePath);
   }
 
   /** {@inheritDoc} */

--- a/src/main/java/com/google/jenkins/plugins/storage/reports/BuildGcsUploadReport.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/reports/BuildGcsUploadReport.java
@@ -15,7 +15,7 @@
  */
 package com.google.jenkins.plugins.storage.reports;
 
-import com.google.common.collect.Sets;
+import com.google.api.client.util.Sets;
 import com.google.jenkins.plugins.storage.util.BucketPath;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
@@ -35,8 +35,8 @@ public class BuildGcsUploadReport extends AbstractGcsUploadReport {
 
   public BuildGcsUploadReport(Run<?, ?> run) {
     super(run);
-    this.buckets = Sets.newConcurrentHashSet();
-    this.files = Sets.newConcurrentHashSet();
+    this.buckets = Sets.newHashSet();
+    this.files = Sets.newHashSet();
   }
 
   /**


### PR DESCRIPTION
Synchronised the files list to prevent the build serialisation job to access it and throw `ConcurrentModificationException` .

## What did I try?

- newConcurrentHashSet

 I used [newConcurrentHashSet](https://guava.dev/releases/20.0/api/docs/com/google/common/collect/Sets.html#newConcurrentHashSet--) rather than the [newHashSet](https://googleapis.dev/java/google-http-client/latest/com/google/api/client/util/Sets.html#newHashSet--) method from the `google-http-client` dependency since it does not support concurrentHash set as far as I see

but it failed when deploying it in one of my production jenkins instance

```
java.lang.NoSuchMethodError: com.google.common.collect.Sets.newConcurrentHashSet()Ljava/util/Set;
```

Closes #61