### PR TITLE
Integrate SECURITY-2458 adaptation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
       Lots of boilerplate from: https://wiki.jenkins-ci.org/display/JENKINS/Hosting+Plugins
   -->
   <artifactId>google-storage-plugin</artifactId>
-  <version>1.5.4.1</version>
+  <version>1.5.4.2-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Google Cloud Storage plugin</name>
@@ -58,7 +58,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}</url>
-    <tag>google-storage-plugin-1.5.4.1</tag>
+    <tag>stable-1.5.4</tag>
   </scm>
 
   <!-- Bring some sanity to version numbering... -->

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
       Lots of boilerplate from: https://wiki.jenkins-ci.org/display/JENKINS/Hosting+Plugins
   -->
   <artifactId>google-storage-plugin</artifactId>
-  <version>1.5.4.1-SNAPSHOT</version>
+  <version>1.5.4.1</version>
   <packaging>hpi</packaging>
 
   <name>Google Cloud Storage plugin</name>
@@ -58,7 +58,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}</url>
-    <tag>stable-1.5.4</tag>
+    <tag>google-storage-plugin-1.5.4.1</tag>
   </scm>
 
   <!-- Bring some sanity to version numbering... -->

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
       Lots of boilerplate from: https://wiki.jenkins-ci.org/display/JENKINS/Hosting+Plugins
   -->
   <artifactId>google-storage-plugin</artifactId>
-  <version>1.5.4</version>
+  <version>1.5.4.1-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Google Cloud Storage plugin</name>
@@ -58,7 +58,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}.git</developerConnection>
     <url>http://github.com/jenkinsci/${project.artifactId}</url>
-    <tag>google-storage-plugin-1.5.4</tag>
+    <tag>stable-1.5.4</tag>
   </scm>
 
   <!-- Bring some sanity to version numbering... -->

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
@@ -51,7 +51,6 @@ import hudson.model.Describable;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
-import hudson.remoting.Callable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
@@ -67,8 +66,8 @@ import java.util.Queue;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import jenkins.model.Jenkins;
+import jenkins.security.MasterToSlaveCallable;
 import org.apache.commons.io.FilenameUtils;
-import org.jenkinsci.remoting.RoleChecker;
 import org.kohsuke.stapler.DataBoundSetter;
 
 /**
@@ -387,7 +386,7 @@ public abstract class AbstractUpload
         final String version = getModule().getVersion();
 
         uploads.workspace.act(
-            new Callable<Void, UploadException>() {
+            new MasterToSlaveCallable<Void, UploadException>() {
               @Override
               public Void call() throws UploadException {
                 performUploads(
@@ -398,12 +397,6 @@ public abstract class AbstractUpload
                     listener,
                     version);
                 return (Void) null;
-              }
-
-              @Override
-              public void checkRoles(RoleChecker checker) throws SecurityException {
-                // We know by definition that this is the correct role;
-                // the callable exists only in this method context.
               }
             });
       } catch (GeneralSecurityException e) {


### PR DESCRIPTION
Should be merged using merge-commit, not squash-merge or rebase-merge, to ensure https://github.com/jenkinsci/google-storage-plugin/releases/tag/google-storage-plugin-1.5.4.1 is in the history of the default branch.

We have not confirmed this is a fix for a security vulnerability, but it was at least risky before.
Context:
https://www.jenkins.io/doc/upgrade-guide/2.303/#SECURITY-2458
https://www.jenkins.io/doc/developer/security/remoting-callables/

CC @donmccasland @rsandell 