### PR TITLE
Make plugin compatible with Guava 31+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,12 +63,11 @@
 
   <!-- Bring some sanity to version numbering... -->
   <properties>
-    <jenkins.version>2.222.4</jenkins.version>
+    <jenkins.version>2.321</jenkins.version>
     <hpi.compatibleSinceVersion>1.5.0</hpi.compatibleSinceVersion>
     <google.api.version>1.25.0</google.api.version>
     <google.http.version>1.21.0</google.http.version>
-    <google.guava.version>30.0-jre</google.guava.version>
-    <google-oauth.version>1.0.0</google-oauth.version>
+    <google-oauth.version>1.0.6</google-oauth.version>
     <storage.revision>158</storage.revision>
     <java.level>8</java.level>
     <concurrency>5</concurrency>
@@ -79,15 +78,16 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.222.x</artifactId>
-        <version>21</version>
+        <artifactId>bom-2.249.x</artifactId>
+        <!-- TODO weekly -->
+        <version>966.v3857b7c82032</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
-        <version>2.6.0</version>
+        <version>2.9.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -133,6 +133,10 @@
       <version>${google.api.version}</version>
       <exclusions>
         <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>com.google.http-client</groupId>
           <artifactId>google-http-client</artifactId>
         </exclusion>
@@ -143,6 +147,10 @@
       <artifactId>google-oauth-client</artifactId>
       <version>${google.api.version}</version>
       <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>com.google.http-client</groupId>
           <artifactId>google-http-client</artifactId>
@@ -155,6 +163,10 @@
       <version>${google.http.version}</version>
       <exclusions>
         <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpclient</artifactId>
         </exclusion>
@@ -166,22 +178,20 @@
       <version>${google.api.version}</version>
       <exclusions>
         <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>com.google.http-client</groupId>
           <artifactId>google-http-client</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- com.google.guava -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${google.guava.version}</version>
-    </dependency>
     <!-- org.joda.time -->
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <version>2.10.5</version>
+      <version>2.10.10</version>
     </dependency>
     <!-- Test dependencies -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -63,11 +63,12 @@
 
   <!-- Bring some sanity to version numbering... -->
   <properties>
-    <jenkins.version>2.321</jenkins.version>
+    <jenkins.version>2.222.4</jenkins.version>
     <hpi.compatibleSinceVersion>1.5.0</hpi.compatibleSinceVersion>
     <google.api.version>1.25.0</google.api.version>
     <google.http.version>1.21.0</google.http.version>
-    <google-oauth.version>1.0.6</google-oauth.version>
+    <google.guava.version>30.0-jre</google.guava.version>
+    <google-oauth.version>1.0.0</google-oauth.version>
     <storage.revision>158</storage.revision>
     <java.level>8</java.level>
     <concurrency>5</concurrency>
@@ -78,16 +79,15 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.249.x</artifactId>
-        <!-- TODO weekly -->
-        <version>966.v3857b7c82032</version>
+        <artifactId>bom-2.222.x</artifactId>
+        <version>21</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
-        <version>2.9.0</version>
+        <version>2.6.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -133,10 +133,6 @@
       <version>${google.api.version}</version>
       <exclusions>
         <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>com.google.http-client</groupId>
           <artifactId>google-http-client</artifactId>
         </exclusion>
@@ -147,10 +143,6 @@
       <artifactId>google-oauth-client</artifactId>
       <version>${google.api.version}</version>
       <exclusions>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
         <exclusion>
           <groupId>com.google.http-client</groupId>
           <artifactId>google-http-client</artifactId>
@@ -163,10 +155,6 @@
       <version>${google.http.version}</version>
       <exclusions>
         <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpclient</artifactId>
         </exclusion>
@@ -178,20 +166,22 @@
       <version>${google.api.version}</version>
       <exclusions>
         <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>com.google.http-client</groupId>
           <artifactId>google-http-client</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
+    <!-- com.google.guava -->
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${google.guava.version}</version>
+    </dependency>
     <!-- org.joda.time -->
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
-      <version>2.10.10</version>
+      <version>2.10.5</version>
     </dependency>
     <!-- Test dependencies -->
     <dependency>

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
@@ -26,7 +26,6 @@ import com.google.api.services.storage.model.StorageObject;
 import com.google.common.base.Objects;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
@@ -64,6 +63,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
@@ -93,12 +94,18 @@ import org.kohsuke.stapler.DataBoundSetter;
 public abstract class AbstractUpload
     implements Describable<AbstractUpload>, ExtensionPoint, Serializable {
   private static final Logger logger = Logger.getLogger(AbstractUpload.class.getName());
-  private static final ImmutableMap<String, String> CONTENT_TYPES =
-      ImmutableMap.of(
-          "css", "text/css",
-          "js", "application/javascript",
-          "svg", "image/svg+xml",
-          "woff2", "font/woff2");
+  private static final Map<String, String> CONTENT_TYPES =
+      Stream.of(
+              new String[][] {
+                {"css", "text/css"},
+                {"js", "application/javascript"},
+                {"svg", "image/svg+xml"},
+                {"woff2", "font/woff2"}
+              })
+          .collect(
+              Collectors.collectingAndThen(
+                  Collectors.toMap(data -> data[0], data -> data[1]),
+                  Collections::<String, String>unmodifiableMap));
   private String pathPrefix;
   // The module to use for providing dependencies.
   private final transient UploadModule module;

--- a/src/main/java/com/google/jenkins/plugins/storage/DownloadStep.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/DownloadStep.java
@@ -58,7 +58,6 @@ import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
-import org.jenkinsci.remoting.RoleChecker;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;

--- a/src/main/java/com/google/jenkins/plugins/storage/StdoutUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/StdoutUpload.java
@@ -16,7 +16,6 @@
 package com.google.jenkins.plugins.storage;
 
 import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.io.ByteStreams.copy;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
@@ -34,6 +33,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import javax.annotation.Nullable;
+import org.apache.commons.io.IOUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
@@ -104,7 +104,7 @@ public class StdoutUpload extends AbstractUpload {
         outputStream = new PlainTextConsoleOutputStream(logFile.write());
 
         inputStream = run.getLogInputStream();
-        copy(inputStream, outputStream);
+        IOUtils.copy(inputStream, outputStream);
 
         return new UploadSpec(logDir, ImmutableList.of(logFile));
       } finally {

--- a/src/main/java/com/google/jenkins/plugins/storage/util/StorageUtil.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/util/StorageUtil.java
@@ -15,7 +15,6 @@
  */
 package com.google.jenkins.plugins.storage.util;
 
-import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.jenkins.plugins.credentials.oauth.GoogleRobotCredentials;
 import com.google.jenkins.plugins.storage.UploadException;
@@ -50,7 +49,7 @@ public class StorageUtil {
         break;
       }
     }
-    return Joiner.on("/").join(segments);
+    return String.join("/", segments);
   }
 
   /**

--- a/src/test/java/com/google/jenkins/plugins/storage/GoogleCloudStorageUploaderTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/GoogleCloudStorageUploaderTest.java
@@ -34,7 +34,6 @@ import com.google.api.services.storage.Storage;
 import com.google.api.services.storage.model.StorageObject;
 import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableList;
-import com.google.common.io.CharStreams;
 import com.google.jenkins.plugins.credentials.oauth.GoogleOAuth2ScopeRequirement;
 import com.google.jenkins.plugins.credentials.oauth.GoogleRobotCredentials;
 import com.google.jenkins.plugins.storage.GoogleCloudStorageUploader.DescriptorImpl;
@@ -52,6 +51,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.util.List;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -235,7 +235,7 @@ public class GoogleCloudStorageUploaderTest {
 
     assertEquals(Result.FAILURE, build.getResult());
     assertThat(
-        CharStreams.toString(new InputStreamReader(build.getLogInputStream())),
+        IOUtils.toString(new InputStreamReader(build.getLogInputStream())),
         containsString("Forbidden"));
   }
 
@@ -273,7 +273,7 @@ public class GoogleCloudStorageUploaderTest {
 
     dumpLog(build);
     assertThat(
-        CharStreams.toString(new InputStreamReader(build.getLogInputStream())),
+        IOUtils.toString(new InputStreamReader(build.getLogInputStream())),
         containsString(Messages.ClassicUpload_NoArtifacts(glob)));
   }
 

--- a/src/test/java/com/google/jenkins/plugins/storage/integration/ITUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/integration/ITUtil.java
@@ -25,7 +25,6 @@ import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.google.common.io.ByteStreams;
 import com.google.jenkins.plugins.credentials.oauth.GoogleRobotPrivateKeyCredentials;
 import com.google.jenkins.plugins.credentials.oauth.JsonServiceAccountConfig;
 import hudson.EnvVars;
@@ -36,6 +35,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import java.util.logging.Logger;
+import org.apache.commons.io.IOUtils;
 import org.jvnet.hudson.test.JenkinsRule;
 
 /** Provides a library of utility functions for integration tests. */
@@ -62,7 +62,7 @@ public class ITUtil {
    * @throws IOException If an error occurred during loading.
    */
   static String loadResource(Class testClass, String name) throws IOException {
-    return new String(ByteStreams.toByteArray(testClass.getResourceAsStream(name)));
+    return new String(IOUtils.toByteArray(testClass.getResourceAsStream(name)));
   }
 
   /**


### PR DESCRIPTION
Update core and BOM dependencies, exclude Guava from a number of other dependencies, remove usage of `Joiner`, `CharStreams`, `ByteStreams`, and `ImmutableMap`.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
