### PR TITLE
fix(upload-report): Add /browser to GCS url

### DIFF
--- a/src/main/resources/com/google/jenkins/plugins/storage/reports/AbstractGcsUploadReport/index.jelly
+++ b/src/main/resources/com/google/jenkins/plugins/storage/reports/AbstractGcsUploadReport/index.jelly
@@ -20,7 +20,7 @@
     <st:include it="${it.parent}" page="sidepanel.jelly" />
     <l:main-panel>
       <h1>Uploaded artifacts (build #${it.buildNumber})</h1>
-        <j:set var="baseUrl" value="https://console.cloud.google.com/storage" />
+        <j:set var="baseUrl" value="https://console.cloud.google.com/storage/browser" />
         <j:set var="downloadUrl" value="https://storage.cloud.google.com" />
         <h3>Buckets</h3>
         <ul>


### PR DESCRIPTION
We just upgraded from 1.5.3 to 1.5.4.1 and the links in the GCS upload report do not work for us and I don't see how they work for anyone. The links currently go to 
```
https://console.cloud.google.com/storage/$bucket/build-log.txt
```
but it should be 
```
https://console.cloud.google.com/storage/browser/$bucket/build-log.txt
```

Don't see where the change was introduced unless it came from an upstream change in `google-cloud-storage`. This would fix the links though.

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
