### PR TITLE
Adapt tests to the new IDs of google credentials

### DIFF
--- a/src/test/java/com/google/jenkins/plugins/storage/client/ClientFactoryTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/client/ClientFactoryTest.java
@@ -18,7 +18,6 @@ package com.google.jenkins.plugins.storage.client;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
-import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.SecretBytes;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
@@ -46,14 +45,15 @@ public class ClientFactoryTest {
     JsonServiceAccountConfig serviceAccountConfig = new JsonServiceAccountConfig();
     serviceAccountConfig.setSecretJsonKey(bytes);
     assertNotNull(serviceAccountConfig.getAccountId());
-    Credentials c =
-        (Credentials) new GoogleRobotPrivateKeyCredentials(ACCOUNT_ID, serviceAccountConfig, null);
+    GoogleRobotPrivateKeyCredentials c =
+        new GoogleRobotPrivateKeyCredentials(ACCOUNT_ID, serviceAccountConfig, null);
+    String credentialsId = c.getId();
     CredentialsStore store = new SystemCredentialsProvider.ProviderImpl().getStore(r.jenkins);
     store.addCredentials(Domain.global(), c);
 
     // Ensure correct exception is thrown
     assertThrows(
         GoogleRobotPrivateKeyCredentials.PrivateKeyNotSetException.class,
-        () -> new ClientFactory(r.jenkins, ImmutableList.of(), ACCOUNT_ID, Optional.empty()));
+        () -> new ClientFactory(r.jenkins, ImmutableList.of(), credentialsId, Optional.empty()));
   }
 }

--- a/src/test/java/com/google/jenkins/plugins/storage/integration/ClassicUploadStepPipelineIT.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/integration/ClassicUploadStepPipelineIT.java
@@ -18,7 +18,7 @@ package com.google.jenkins.plugins.storage.integration;
 
 import static com.google.jenkins.plugins.storage.integration.ITUtil.dumpLog;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.formatRandomName;
-import static com.google.jenkins.plugins.storage.integration.ITUtil.getCredentialsId;
+import static com.google.jenkins.plugins.storage.integration.ITUtil.getProjectId;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.initializePipelineITEnvironment;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.loadResource;
 import static org.junit.Assert.assertNotNull;
@@ -53,7 +53,7 @@ public class ClassicUploadStepPipelineIT {
     LOGGER.info("Initializing ClassicUploadStepPipelineIT");
 
     envVars = initializePipelineITEnvironment(pattern, jenkinsRule);
-    credentialsId = getCredentialsId();
+    credentialsId = envVars.get("CREDENTIALS_ID");
     storageClient = new ClientFactory(jenkinsRule.jenkins, credentialsId).storageClient();
     bucket = formatRandomName("test");
     envVars.put("BUCKET", bucket);

--- a/src/test/java/com/google/jenkins/plugins/storage/integration/ClassicUploadStepPipelineIT.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/integration/ClassicUploadStepPipelineIT.java
@@ -18,7 +18,6 @@ package com.google.jenkins.plugins.storage.integration;
 
 import static com.google.jenkins.plugins.storage.integration.ITUtil.dumpLog;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.formatRandomName;
-import static com.google.jenkins.plugins.storage.integration.ITUtil.getProjectId;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.initializePipelineITEnvironment;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.loadResource;
 import static org.junit.Assert.assertNotNull;

--- a/src/test/java/com/google/jenkins/plugins/storage/integration/DownloadStepPipelineIT.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/integration/DownloadStepPipelineIT.java
@@ -19,7 +19,7 @@ package com.google.jenkins.plugins.storage.integration;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.dumpLog;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.formatRandomName;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.getBucket;
-import static com.google.jenkins.plugins.storage.integration.ITUtil.getCredentialsId;
+import static com.google.jenkins.plugins.storage.integration.ITUtil.getProjectId;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.initializePipelineITEnvironment;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.loadResource;
 import static org.junit.Assert.assertNotNull;
@@ -57,7 +57,7 @@ public class DownloadStepPipelineIT {
     LOGGER.info("Initializing DownloadStepPipelineIT");
 
     envVars = initializePipelineITEnvironment(pattern, jenkinsRule);
-    credentialsId = getCredentialsId();
+    credentialsId = envVars.get("CREDENTIALS_ID");
     storageClient = new ClientFactory(jenkinsRule.jenkins, credentialsId).storageClient();
     bucket = getBucket();
 

--- a/src/test/java/com/google/jenkins/plugins/storage/integration/DownloadStepPipelineIT.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/integration/DownloadStepPipelineIT.java
@@ -19,7 +19,6 @@ package com.google.jenkins.plugins.storage.integration;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.dumpLog;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.formatRandomName;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.getBucket;
-import static com.google.jenkins.plugins.storage.integration.ITUtil.getProjectId;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.initializePipelineITEnvironment;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.loadResource;
 import static org.junit.Assert.assertNotNull;

--- a/src/test/java/com/google/jenkins/plugins/storage/integration/ExpiringBucketLifeCycleManagerIT.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/integration/ExpiringBucketLifeCycleManagerIT.java
@@ -17,7 +17,7 @@ package com.google.jenkins.plugins.storage.integration;
 
 import static com.google.jenkins.plugins.storage.integration.ITUtil.dumpLog;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.formatRandomName;
-import static com.google.jenkins.plugins.storage.integration.ITUtil.getCredentialsId;
+import static com.google.jenkins.plugins.storage.integration.ITUtil.getProjectId;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.initializePipelineITEnvironment;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.loadResource;
 import static org.junit.Assert.assertNotNull;
@@ -52,7 +52,7 @@ public class ExpiringBucketLifeCycleManagerIT {
     LOGGER.info("Initializing ExpiringBucketLifeCycleManagerIT");
 
     envVars = initializePipelineITEnvironment(pattern, jenkinsRule);
-    credentialsId = getCredentialsId();
+    credentialsId = envVars.get("CREDENTIALS_ID");
     storageClient = new ClientFactory(jenkinsRule.jenkins, credentialsId).storageClient();
     // Create new test bucket to change lifecycle of objects on.
     bucket = formatRandomName("test");

--- a/src/test/java/com/google/jenkins/plugins/storage/integration/ExpiringBucketLifeCycleManagerIT.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/integration/ExpiringBucketLifeCycleManagerIT.java
@@ -17,7 +17,6 @@ package com.google.jenkins.plugins.storage.integration;
 
 import static com.google.jenkins.plugins.storage.integration.ITUtil.dumpLog;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.formatRandomName;
-import static com.google.jenkins.plugins.storage.integration.ITUtil.getProjectId;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.initializePipelineITEnvironment;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.loadResource;
 import static org.junit.Assert.assertNotNull;

--- a/src/test/java/com/google/jenkins/plugins/storage/integration/ITUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/integration/ITUtil.java
@@ -18,7 +18,6 @@ package com.google.jenkins.plugins.storage.integration;
 
 import static org.junit.Assert.assertNotNull;
 
-import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.SecretBytes;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
@@ -85,7 +84,7 @@ public class ITUtil {
    *
    * @return the credentialsId
    */
-  static String getCredentialsId() {
+  static String getProjectId() {
     return projectId;
   }
 
@@ -108,21 +107,22 @@ public class ITUtil {
     assertNotNull("GOOGLE_BUCKET env var must be set", bucket);
     String serviceAccountKeyJson = System.getenv("GOOGLE_CREDENTIALS");
     assertNotNull("GOOGLE_CREDENTIALS env var must be set", serviceAccountKeyJson);
-    String credentialsId = getCredentialsId();
+    String projectId = getProjectId();
     Preconditions.checkArgument(!Strings.isNullOrEmpty(pattern));
 
     SecretBytes secretBytes =
         SecretBytes.fromBytes(serviceAccountKeyJson.getBytes(StandardCharsets.UTF_8));
     JsonServiceAccountConfig sac = new JsonServiceAccountConfig();
     sac.setSecretJsonKey(secretBytes);
-    Credentials c = new GoogleRobotPrivateKeyCredentials(credentialsId, sac, null);
+    GoogleRobotPrivateKeyCredentials c = new GoogleRobotPrivateKeyCredentials(projectId, sac, null);
+    String credentialId = c.getId();
     CredentialsStore store =
         new SystemCredentialsProvider.ProviderImpl().getStore(jenkinsRule.jenkins);
     store.addCredentials(Domain.global(), c);
 
     EnvironmentVariablesNodeProperty prop = new EnvironmentVariablesNodeProperty();
     EnvVars envVars = prop.getEnvVars();
-    envVars.put("CREDENTIALS_ID", credentialsId);
+    envVars.put("CREDENTIALS_ID", credentialId);
     envVars.put("BUCKET", bucket);
     envVars.put("PATTERN", pattern);
     jenkinsRule.jenkins.getGlobalNodeProperties().add(prop);

--- a/src/test/java/com/google/jenkins/plugins/storage/integration/StdoutUploadStepPipelineIT.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/integration/StdoutUploadStepPipelineIT.java
@@ -18,7 +18,6 @@ package com.google.jenkins.plugins.storage.integration;
 
 import static com.google.jenkins.plugins.storage.integration.ITUtil.dumpLog;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.formatRandomName;
-import static com.google.jenkins.plugins.storage.integration.ITUtil.getProjectId;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.initializePipelineITEnvironment;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.loadResource;
 import static org.junit.Assert.assertNotNull;

--- a/src/test/java/com/google/jenkins/plugins/storage/integration/StdoutUploadStepPipelineIT.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/integration/StdoutUploadStepPipelineIT.java
@@ -18,7 +18,7 @@ package com.google.jenkins.plugins.storage.integration;
 
 import static com.google.jenkins.plugins.storage.integration.ITUtil.dumpLog;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.formatRandomName;
-import static com.google.jenkins.plugins.storage.integration.ITUtil.getCredentialsId;
+import static com.google.jenkins.plugins.storage.integration.ITUtil.getProjectId;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.initializePipelineITEnvironment;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.loadResource;
 import static org.junit.Assert.assertNotNull;
@@ -53,7 +53,7 @@ public class StdoutUploadStepPipelineIT {
     LOGGER.info("Initializing StdoutUploadStepPipelineIT");
 
     envVars = initializePipelineITEnvironment(pattern, jenkinsRule);
-    credentialsId = getCredentialsId();
+    credentialsId = envVars.get("CREDENTIALS_ID");
     storageClient = new ClientFactory(jenkinsRule.jenkins, credentialsId).storageClient();
     bucket = formatRandomName("test");
     envVars.put("BUCKET", bucket);


### PR DESCRIPTION
After https://github.com/jenkinsci/google-oauth-plugin/pull/186 , there is now a real ID field for the google credentials, instead of the project ID being returned in the `getId()`. Thus, tests no longer should assume that the ID of a credential they just created will be the project ID they passed into it, and should instead `getId()` on the newly created credential to recognize this credential.

### Testing done
The IT tests seem to not be run on the CI by default, but we ran them locally, and they did indeed fail before the changes with the updated google-oauth-plugin, and passed after them.


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
