### PR TITLE
Adapt tests to updated version of google-oauth-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <gitHubRepo>jenkinsci/${project.artifactId}</gitHubRepo>
     <hpi.compatibleSinceVersion>1.5.0</hpi.compatibleSinceVersion>
     <google.api.version>1.35.2</google.api.version>
-    <google.http.version>1.42.2</google.http.version>
+    <google.http.version>1.43.3</google.http.version>
     <google.guava.version>32.1.2-jre</google.guava.version>
     <google-oauth.version>1.34.1</google-oauth.version>
     <storage.revision>20220705</storage.revision>

--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,8 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>google-oauth-plugin</artifactId>
+      <!-- TODO: Remove this version when it is integrated in Jenkins BOM -->
+      <version>1.318.vb_39c5db_e3041</version>
       <exclusions>
         <exclusion>
           <groupId>net.sourceforge.findbugs</groupId>

--- a/src/test/java/com/google/jenkins/plugins/storage/client/ClientFactoryTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/client/ClientFactoryTest.java
@@ -18,6 +18,7 @@ package com.google.jenkins.plugins.storage.client;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
+import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.SecretBytes;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
@@ -41,19 +42,21 @@ public class ClientFactoryTest {
 
   @Test
   public void defaultTransport() throws Exception {
+    final String credentialId = "my-google-credential";
+
     SecretBytes bytes = SecretBytes.fromBytes(PK_BYTES);
     JsonServiceAccountConfig serviceAccountConfig = new JsonServiceAccountConfig();
     serviceAccountConfig.setSecretJsonKey(bytes);
     assertNotNull(serviceAccountConfig.getAccountId());
-    GoogleRobotPrivateKeyCredentials c =
-        new GoogleRobotPrivateKeyCredentials(ACCOUNT_ID, serviceAccountConfig, null);
-    String credentialsId = c.getId();
+
+    GoogleRobotPrivateKeyCredentials c = new GoogleRobotPrivateKeyCredentials(CredentialsScope.GLOBAL, credentialId, ACCOUNT_ID, serviceAccountConfig, null);
     CredentialsStore store = new SystemCredentialsProvider.ProviderImpl().getStore(r.jenkins);
+    assertNotNull(store);
     store.addCredentials(Domain.global(), c);
 
     // Ensure correct exception is thrown
     assertThrows(
         GoogleRobotPrivateKeyCredentials.PrivateKeyNotSetException.class,
-        () -> new ClientFactory(r.jenkins, ImmutableList.of(), credentialsId, Optional.empty()));
+        () -> new ClientFactory(r.jenkins, ImmutableList.of(), credentialId, Optional.empty()));
   }
 }

--- a/src/test/java/com/google/jenkins/plugins/storage/client/ClientFactoryTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/client/ClientFactoryTest.java
@@ -18,7 +18,6 @@ package com.google.jenkins.plugins.storage.client;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
-import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.SecretBytes;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
@@ -46,14 +45,15 @@ public class ClientFactoryTest {
     JsonServiceAccountConfig serviceAccountConfig = new JsonServiceAccountConfig();
     serviceAccountConfig.setSecretJsonKey(bytes);
     assertNotNull(serviceAccountConfig.getAccountId());
-    Credentials c =
-        (Credentials) new GoogleRobotPrivateKeyCredentials(ACCOUNT_ID, serviceAccountConfig, null);
+    GoogleRobotPrivateKeyCredentials c =
+        new GoogleRobotPrivateKeyCredentials(ACCOUNT_ID, serviceAccountConfig, null);
+    String credentialsId = c.getId();
     CredentialsStore store = new SystemCredentialsProvider.ProviderImpl().getStore(r.jenkins);
     store.addCredentials(Domain.global(), c);
 
     // Ensure correct exception is thrown
     assertThrows(
         GoogleRobotPrivateKeyCredentials.PrivateKeyNotSetException.class,
-        () -> new ClientFactory(r.jenkins, ImmutableList.of(), ACCOUNT_ID, Optional.empty()));
+        () -> new ClientFactory(r.jenkins, ImmutableList.of(), credentialsId, Optional.empty()));
   }
 }

--- a/src/test/java/com/google/jenkins/plugins/storage/client/ClientFactoryTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/client/ClientFactoryTest.java
@@ -49,7 +49,9 @@ public class ClientFactoryTest {
     serviceAccountConfig.setSecretJsonKey(bytes);
     assertNotNull(serviceAccountConfig.getAccountId());
 
-    GoogleRobotPrivateKeyCredentials c = new GoogleRobotPrivateKeyCredentials(CredentialsScope.GLOBAL, credentialId, ACCOUNT_ID, serviceAccountConfig, null);
+    GoogleRobotPrivateKeyCredentials c =
+        new GoogleRobotPrivateKeyCredentials(
+            CredentialsScope.GLOBAL, credentialId, ACCOUNT_ID, serviceAccountConfig, null);
     CredentialsStore store = new SystemCredentialsProvider.ProviderImpl().getStore(r.jenkins);
     assertNotNull(store);
     store.addCredentials(Domain.global(), c);

--- a/src/test/java/com/google/jenkins/plugins/storage/integration/ClassicUploadStepPipelineIT.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/integration/ClassicUploadStepPipelineIT.java
@@ -18,7 +18,7 @@ package com.google.jenkins.plugins.storage.integration;
 
 import static com.google.jenkins.plugins.storage.integration.ITUtil.dumpLog;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.formatRandomName;
-import static com.google.jenkins.plugins.storage.integration.ITUtil.getCredentialsId;
+import static com.google.jenkins.plugins.storage.integration.ITUtil.getProjectId;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.initializePipelineITEnvironment;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.loadResource;
 import static org.junit.Assert.assertNotNull;
@@ -53,7 +53,7 @@ public class ClassicUploadStepPipelineIT {
     LOGGER.info("Initializing ClassicUploadStepPipelineIT");
 
     envVars = initializePipelineITEnvironment(pattern, jenkinsRule);
-    credentialsId = getCredentialsId();
+    credentialsId = envVars.get("CREDENTIALS_ID");
     storageClient = new ClientFactory(jenkinsRule.jenkins, credentialsId).storageClient();
     bucket = formatRandomName("test");
     envVars.put("BUCKET", bucket);

--- a/src/test/java/com/google/jenkins/plugins/storage/integration/ClassicUploadStepPipelineIT.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/integration/ClassicUploadStepPipelineIT.java
@@ -18,7 +18,6 @@ package com.google.jenkins.plugins.storage.integration;
 
 import static com.google.jenkins.plugins.storage.integration.ITUtil.dumpLog;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.formatRandomName;
-import static com.google.jenkins.plugins.storage.integration.ITUtil.getProjectId;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.initializePipelineITEnvironment;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.loadResource;
 import static org.junit.Assert.assertNotNull;

--- a/src/test/java/com/google/jenkins/plugins/storage/integration/DownloadStepPipelineIT.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/integration/DownloadStepPipelineIT.java
@@ -19,7 +19,7 @@ package com.google.jenkins.plugins.storage.integration;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.dumpLog;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.formatRandomName;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.getBucket;
-import static com.google.jenkins.plugins.storage.integration.ITUtil.getCredentialsId;
+import static com.google.jenkins.plugins.storage.integration.ITUtil.getProjectId;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.initializePipelineITEnvironment;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.loadResource;
 import static org.junit.Assert.assertNotNull;
@@ -57,7 +57,7 @@ public class DownloadStepPipelineIT {
     LOGGER.info("Initializing DownloadStepPipelineIT");
 
     envVars = initializePipelineITEnvironment(pattern, jenkinsRule);
-    credentialsId = getCredentialsId();
+    credentialsId = envVars.get("CREDENTIALS_ID");
     storageClient = new ClientFactory(jenkinsRule.jenkins, credentialsId).storageClient();
     bucket = getBucket();
 

--- a/src/test/java/com/google/jenkins/plugins/storage/integration/DownloadStepPipelineIT.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/integration/DownloadStepPipelineIT.java
@@ -19,7 +19,6 @@ package com.google.jenkins.plugins.storage.integration;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.dumpLog;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.formatRandomName;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.getBucket;
-import static com.google.jenkins.plugins.storage.integration.ITUtil.getProjectId;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.initializePipelineITEnvironment;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.loadResource;
 import static org.junit.Assert.assertNotNull;

--- a/src/test/java/com/google/jenkins/plugins/storage/integration/ExpiringBucketLifeCycleManagerIT.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/integration/ExpiringBucketLifeCycleManagerIT.java
@@ -17,7 +17,7 @@ package com.google.jenkins.plugins.storage.integration;
 
 import static com.google.jenkins.plugins.storage.integration.ITUtil.dumpLog;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.formatRandomName;
-import static com.google.jenkins.plugins.storage.integration.ITUtil.getCredentialsId;
+import static com.google.jenkins.plugins.storage.integration.ITUtil.getProjectId;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.initializePipelineITEnvironment;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.loadResource;
 import static org.junit.Assert.assertNotNull;
@@ -52,7 +52,7 @@ public class ExpiringBucketLifeCycleManagerIT {
     LOGGER.info("Initializing ExpiringBucketLifeCycleManagerIT");
 
     envVars = initializePipelineITEnvironment(pattern, jenkinsRule);
-    credentialsId = getCredentialsId();
+    credentialsId = envVars.get("CREDENTIALS_ID");
     storageClient = new ClientFactory(jenkinsRule.jenkins, credentialsId).storageClient();
     // Create new test bucket to change lifecycle of objects on.
     bucket = formatRandomName("test");

--- a/src/test/java/com/google/jenkins/plugins/storage/integration/ExpiringBucketLifeCycleManagerIT.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/integration/ExpiringBucketLifeCycleManagerIT.java
@@ -17,7 +17,6 @@ package com.google.jenkins.plugins.storage.integration;
 
 import static com.google.jenkins.plugins.storage.integration.ITUtil.dumpLog;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.formatRandomName;
-import static com.google.jenkins.plugins.storage.integration.ITUtil.getProjectId;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.initializePipelineITEnvironment;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.loadResource;
 import static org.junit.Assert.assertNotNull;

--- a/src/test/java/com/google/jenkins/plugins/storage/integration/ITUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/integration/ITUtil.java
@@ -18,7 +18,6 @@ package com.google.jenkins.plugins.storage.integration;
 
 import static org.junit.Assert.assertNotNull;
 
-import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.SecretBytes;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
@@ -85,7 +84,7 @@ public class ITUtil {
    *
    * @return the credentialsId
    */
-  static String getCredentialsId() {
+  static String getProjectId() {
     return projectId;
   }
 
@@ -108,21 +107,22 @@ public class ITUtil {
     assertNotNull("GOOGLE_BUCKET env var must be set", bucket);
     String serviceAccountKeyJson = System.getenv("GOOGLE_CREDENTIALS");
     assertNotNull("GOOGLE_CREDENTIALS env var must be set", serviceAccountKeyJson);
-    String credentialsId = getCredentialsId();
+    String projectId = getProjectId();
     Preconditions.checkArgument(!Strings.isNullOrEmpty(pattern));
 
     SecretBytes secretBytes =
         SecretBytes.fromBytes(serviceAccountKeyJson.getBytes(StandardCharsets.UTF_8));
     JsonServiceAccountConfig sac = new JsonServiceAccountConfig();
     sac.setSecretJsonKey(secretBytes);
-    Credentials c = new GoogleRobotPrivateKeyCredentials(credentialsId, sac, null);
+    GoogleRobotPrivateKeyCredentials c = new GoogleRobotPrivateKeyCredentials(projectId, sac, null);
+    String credentialId = c.getId();
     CredentialsStore store =
         new SystemCredentialsProvider.ProviderImpl().getStore(jenkinsRule.jenkins);
     store.addCredentials(Domain.global(), c);
 
     EnvironmentVariablesNodeProperty prop = new EnvironmentVariablesNodeProperty();
     EnvVars envVars = prop.getEnvVars();
-    envVars.put("CREDENTIALS_ID", credentialsId);
+    envVars.put("CREDENTIALS_ID", credentialId);
     envVars.put("BUCKET", bucket);
     envVars.put("PATTERN", pattern);
     jenkinsRule.jenkins.getGlobalNodeProperties().add(prop);

--- a/src/test/java/com/google/jenkins/plugins/storage/integration/ITUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/integration/ITUtil.java
@@ -44,10 +44,12 @@ public class ITUtil {
   private static String bucket = System.getenv("GOOGLE_BUCKET");
 
   // DEV MEMO:
-  // In previous versions of google-oauth-plugin, the credentialId was actually the projectId, making it impossible to have several credentials for
+  // In previous versions of google-oauth-plugin, the credentialId was actually the projectId,
+  // making it impossible to have several credentials for
   // the same project.
   // This property will allow to override the credentialId to use for the tests.
-  // If it is not set, it will default to the projectId for the tests to match with the former behavior.
+  // If it is not set, it will default to the projectId for the tests to match with the former
+  // behavior.
   private static String credentialId = System.getenv("GOOGLE_CREDENTIAL_ID");
 
   /**
@@ -117,7 +119,9 @@ public class ITUtil {
     JsonServiceAccountConfig sac = new JsonServiceAccountConfig();
     sac.setSecretJsonKey(secretBytes);
 
-    GoogleRobotPrivateKeyCredentials c = new GoogleRobotPrivateKeyCredentials(CredentialsScope.GLOBAL, credentialId, projectId, sac, null);
+    GoogleRobotPrivateKeyCredentials c =
+        new GoogleRobotPrivateKeyCredentials(
+            CredentialsScope.GLOBAL, credentialId, projectId, sac, null);
     CredentialsStore store =
         new SystemCredentialsProvider.ProviderImpl().getStore(jenkinsRule.jenkins);
     assertNotNull(store);

--- a/src/test/java/com/google/jenkins/plugins/storage/integration/ITUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/integration/ITUtil.java
@@ -18,6 +18,7 @@ package com.google.jenkins.plugins.storage.integration;
 
 import static org.junit.Assert.assertNotNull;
 
+import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.SecretBytes;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
@@ -41,6 +42,13 @@ import org.jvnet.hudson.test.JenkinsRule;
 public class ITUtil {
   private static String projectId = System.getenv("GOOGLE_PROJECT_ID");
   private static String bucket = System.getenv("GOOGLE_BUCKET");
+
+  // DEV MEMO:
+  // In previous versions of google-oauth-plugin, the credentialId was actually the projectId, making it impossible to have several credentials for
+  // the same project.
+  // This property will allow to override the credentialId to use for the tests.
+  // If it is not set, it will default to the projectId for the tests to match with the former behavior.
+  private static String credentialId = System.getenv("GOOGLE_CREDENTIAL_ID");
 
   /**
    * Formats a random name using the given prefix.
@@ -79,15 +87,6 @@ public class ITUtil {
     }
   }
 
-  /**
-   * Returns the credentialsId, which is the same as the projectId.
-   *
-   * @return the credentialsId
-   */
-  static String getProjectId() {
-    return projectId;
-  }
-
   static String getBucket() {
     return bucket;
   }
@@ -107,17 +106,21 @@ public class ITUtil {
     assertNotNull("GOOGLE_BUCKET env var must be set", bucket);
     String serviceAccountKeyJson = System.getenv("GOOGLE_CREDENTIALS");
     assertNotNull("GOOGLE_CREDENTIALS env var must be set", serviceAccountKeyJson);
-    String projectId = getProjectId();
     Preconditions.checkArgument(!Strings.isNullOrEmpty(pattern));
+
+    if (credentialId == null || credentialId.isEmpty()) {
+      credentialId = projectId;
+    }
 
     SecretBytes secretBytes =
         SecretBytes.fromBytes(serviceAccountKeyJson.getBytes(StandardCharsets.UTF_8));
     JsonServiceAccountConfig sac = new JsonServiceAccountConfig();
     sac.setSecretJsonKey(secretBytes);
-    GoogleRobotPrivateKeyCredentials c = new GoogleRobotPrivateKeyCredentials(projectId, sac, null);
-    String credentialId = c.getId();
+
+    GoogleRobotPrivateKeyCredentials c = new GoogleRobotPrivateKeyCredentials(CredentialsScope.GLOBAL, credentialId, projectId, sac, null);
     CredentialsStore store =
         new SystemCredentialsProvider.ProviderImpl().getStore(jenkinsRule.jenkins);
+    assertNotNull(store);
     store.addCredentials(Domain.global(), c);
 
     EnvironmentVariablesNodeProperty prop = new EnvironmentVariablesNodeProperty();

--- a/src/test/java/com/google/jenkins/plugins/storage/integration/StdoutUploadStepPipelineIT.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/integration/StdoutUploadStepPipelineIT.java
@@ -18,7 +18,6 @@ package com.google.jenkins.plugins.storage.integration;
 
 import static com.google.jenkins.plugins.storage.integration.ITUtil.dumpLog;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.formatRandomName;
-import static com.google.jenkins.plugins.storage.integration.ITUtil.getProjectId;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.initializePipelineITEnvironment;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.loadResource;
 import static org.junit.Assert.assertNotNull;

--- a/src/test/java/com/google/jenkins/plugins/storage/integration/StdoutUploadStepPipelineIT.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/integration/StdoutUploadStepPipelineIT.java
@@ -18,7 +18,7 @@ package com.google.jenkins.plugins.storage.integration;
 
 import static com.google.jenkins.plugins.storage.integration.ITUtil.dumpLog;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.formatRandomName;
-import static com.google.jenkins.plugins.storage.integration.ITUtil.getCredentialsId;
+import static com.google.jenkins.plugins.storage.integration.ITUtil.getProjectId;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.initializePipelineITEnvironment;
 import static com.google.jenkins.plugins.storage.integration.ITUtil.loadResource;
 import static org.junit.Assert.assertNotNull;
@@ -53,7 +53,7 @@ public class StdoutUploadStepPipelineIT {
     LOGGER.info("Initializing StdoutUploadStepPipelineIT");
 
     envVars = initializePipelineITEnvironment(pattern, jenkinsRule);
-    credentialsId = getCredentialsId();
+    credentialsId = envVars.get("CREDENTIALS_ID");
     storageClient = new ClientFactory(jenkinsRule.jenkins, credentialsId).storageClient();
     bucket = formatRandomName("test");
     envVars.put("BUCKET", bucket);


### PR DESCRIPTION
Supersedes https://github.com/jenkinsci/google-storage-plugin/pull/263

Hello :wave:

Since https://github.com/jenkinsci/google-oauth-plugin/pull/186, the constructor `public GoogleRobotPrivateKeyCredentials(String projectId, ServiceAccountConfig serviceAccountConfig, @Nullable GoogleRobotCredentialsModule module)` was deprecated in favor of one allowing to specify explicitly the credential ID.
This PR provides an update in the automated tests making use of the up-to-date constructor.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
