### PR TITLE
Use Guava from Jenkins core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,6 @@
     <hpi.compatibleSinceVersion>1.5.0</hpi.compatibleSinceVersion>
     <google.api.version>1.35.2</google.api.version>
     <google.http.version>1.43.3</google.http.version>
-    <google.guava.version>32.1.2-jre</google.guava.version>
     <google-oauth.version>1.34.1</google-oauth.version>
     <storage.revision>20220705</storage.revision>
     <concurrency>5</concurrency>
@@ -159,6 +158,10 @@
           <artifactId>google-http-client</artifactId>
         </exclusion>
         <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpcore</artifactId>
         </exclusion>
@@ -181,6 +184,10 @@
           <groupId>com.google.http-client</groupId>
           <artifactId>google-http-client</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -191,6 +198,10 @@
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>
           <artifactId>jsr305</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.httpcomponents</groupId>
@@ -210,18 +221,6 @@
         <exclusion>
           <groupId>com.google.http-client</groupId>
           <artifactId>google-http-client</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <!-- com.google.guava -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${google.guava.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>jsr305</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -373,13 +372,6 @@
           <skipTests>${skip.surefire.tests}</skipTests>
           <runOrder>balanced</runOrder>
           <reuseForks>false</reuseForks>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.jenkins-ci.tools</groupId>
-        <artifactId>maven-hpi-plugin</artifactId>
-        <configuration>
-          <maskClasses>com.google.common.</maskClasses>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Now that core includes a recent version of Guava, there is no need to bundle our own.

- https://github.com/jenkinsci/google-oauth-plugin/pull/206
- https://github.com/jenkinsci/google-kubernetes-engine-plugin/pull/360
- https://github.com/jenkinsci/google-storage-plugin/pull/268