### PR TITLE
Remove unnecessary JARs from HPI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,11 +106,6 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.11.0</version>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
     </dependency>
@@ -132,9 +127,8 @@
       <artifactId>ssh-credentials</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.12.0</version>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>commons-lang3-api</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -198,6 +192,10 @@
         <exclusion>
           <groupId>com.google.code.findbugs</groupId>
           <artifactId>jsr305</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.errorprone</groupId>
+          <artifactId>error_prone_annotations</artifactId>
         </exclusion>
         <exclusion>
           <groupId>com.google.guava</groupId>


### PR DESCRIPTION
Stop bundling these unnecessary JARs:

- `WEB-INF/lib/commons-io-2.11.0.jar`
- `WEB-INF/lib/commons-lang3-3.12.0.jar`
- `WEB-INF/lib/error_prone_annotations-2.18.0.jar`

Commons IO is provided by core. In place of bundling Commons Lang 3, we use the library plugin as is generally recommended. Error Prone annotations are not needed at runtime, so exclude them to avoid upper bounds errors relating to them.