### PR TITLE
Use Jenkins project-wide formatting configuration

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -36,12 +36,12 @@ by Joshua Bloch in his book Effective Java -->
   <module name="RegexpSingleline">
     <!-- Checks that TODOs are properly formatted.
 
-         The (?&lt;!TODO\(.{0,100}) makes the regex ignore any secondary TODO's on the line
+         The (?&lt;!TODO\(.{0,120}) makes the regex ignore any secondary TODO's on the line
          so that things like //TODO(bob): remove this TODO on 1/1/2020 don't trigger a warning
-         because of the second TODO.  (The {0,100} is because java doesn't recoginize arbitrary
-         length look backs, but we know each java line should be < 100 chars.)
+         because of the second TODO.  (The {0,120} is because java doesn't recoginize arbitrary
+         length look backs, but we know each java line should be < 120 chars.)
     -->
-    <property name="format" value="((//.*)|(\*.*))(?&lt;!TODO\(.{0,100})(TODO[^(])|(TODO\([^)]*$)" />
+    <property name="format" value="((//.*)|(\*.*))(?&lt;!TODO\(.{0,120})(TODO[^(])|(TODO\([^)]*$)" />
     <property name="message" value='All TODOs should be named.  e.g. "TODO(johndoe): Refactor when v2 is released."' />
   </module>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,12 +16,11 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.72</version>
-    <relativePath/>
+    <version>4.76</version>
+    <relativePath />
   </parent>
 
   <!--
@@ -30,9 +29,9 @@
   <artifactId>google-storage-plugin</artifactId>
   <version>${revision}.${changelist}</version>
   <packaging>hpi</packaging>
-
   <name>Google Cloud Storage plugin</name>
   <url>https://github.com/jenkinsci/${project.artifactId}/blob/develop/docs/home.md</url>
+
   <licenses>
     <license>
       <name>The Apache V2 License</name>
@@ -57,8 +56,8 @@
   <scm>
     <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
-    <url>https://github.com/${gitHubRepo}</url>
     <tag>${scmTag}</tag>
+    <url>https://github.com/${gitHubRepo}</url>
   </scm>
 
   <!-- Bring some sanity to version numbering... -->
@@ -76,6 +75,7 @@
     <skipIts>true</skipIts>
     <!-- TODO some violations remaining -->
     <spotbugs.threshold>High</spotbugs.threshold>
+    <spotless.check.skip>false</spotless.check.skip>
   </properties>
 
   <dependencyManagement>
@@ -104,40 +104,8 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+
   <dependencies>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>credentials</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>structs</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkinsci.plugins</groupId>
-      <artifactId>pipeline-model-definition</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins.workflow</groupId>
-      <artifactId>workflow-step-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>ssh-credentials</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.jenkins.plugins</groupId>
-      <artifactId>commons-lang3-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>jackson2-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>apache-httpcomponents-client-4-api</artifactId>
-    </dependency>
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
@@ -148,39 +116,33 @@
           <artifactId>jsr305</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>com.google.http-client</groupId>
-          <artifactId>google-http-client</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
         </exclusion>
         <exclusion>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpcore</artifactId>
+          <groupId>com.google.http-client</groupId>
+          <artifactId>google-http-client</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.httpcomponents</groupId>
           <artifactId>httpclient</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
+    <!-- com.google.apis -->
+    <!-- https://developers.google.com/api-client-library/java/apis/storage/v1 -->
     <dependency>
-      <groupId>com.google.oauth-client</groupId>
-      <artifactId>google-oauth-client</artifactId>
-      <version>${google-oauth.version}</version>
+      <groupId>com.google.apis</groupId>
+      <artifactId>google-api-services-storage</artifactId>
+      <version>v1-rev20220705-1.32.1</version>
       <exclusions>
-        <exclusion>
-          <groupId>com.google.code.findbugs</groupId>
-          <artifactId>jsr305</artifactId>
-        </exclusion>
         <exclusion>
           <groupId>com.google.http-client</groupId>
           <artifactId>google-http-client</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
@@ -217,10 +179,37 @@
       <version>${google.http.version}</version>
       <exclusions>
         <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-core</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>com.google.http-client</groupId>
           <artifactId>google-http-client</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.google.oauth-client</groupId>
+      <artifactId>google-oauth-client</artifactId>
+      <version>${google-oauth.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.http-client</groupId>
+          <artifactId>google-http-client</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>commons-lang3-api</artifactId>
     </dependency>
     <!-- org.joda.time -->
     <dependency>
@@ -228,11 +217,18 @@
       <artifactId>joda-time</artifactId>
       <version>2.12.5</version>
     </dependency>
-    <!-- Test dependencies -->
     <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>apache-httpcomponents-client-4-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials</artifactId>
+    </dependency>
+    <!-- Metadata dependency -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>google-metadata-plugin</artifactId>
     </dependency>
     <!-- Auth dependency -->
     <dependency>
@@ -242,28 +238,41 @@
       <version>1.318.vb_39c5db_e3041</version>
       <exclusions>
         <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+        <exclusion>
           <groupId>net.sourceforge.findbugs</groupId>
           <artifactId>jsr305</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- Metadata dependency -->
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>google-metadata-plugin</artifactId>
+      <artifactId>jackson2-api</artifactId>
     </dependency>
-    <!-- com.google.apis -->
-    <!-- https://developers.google.com/api-client-library/java/apis/storage/v1 -->
     <dependency>
-      <groupId>com.google.apis</groupId>
-      <artifactId>google-api-services-storage</artifactId>
-      <version>v1-rev20220705-1.32.1</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.http-client</groupId>
-          <artifactId>google-http-client</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>ssh-credentials</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>structs</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-step-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkinsci.plugins</groupId>
+      <artifactId>pipeline-model-definition</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 
@@ -283,55 +292,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>au.com.acegi</groupId>
-        <artifactId>xml-format-maven-plugin</artifactId>
-        <version>3.1.2</version>
-        <executions>
-          <execution>
-            <id>validate</id>
-            <phase>validate</phase>
-            <goals>
-              <goal>xml-format</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <includes>pom.xml</includes>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>tidy-maven-plugin</artifactId>
-        <version>1.2.0</version>
-        <executions>
-          <execution>
-            <id>validate</id>
-            <phase>validate</phase>
-            <goals>
-              <goal>pom</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>com.spotify.fmt</groupId>
-        <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.20</version>
-        <configuration>
-          <verbose>true</verbose>
-          <skipSortingImports>false</skipSortingImports>
-          <style>google</style>
-        </configuration>
-        <executions>
-          <execution>
-            <id>check-source-format</id>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>cobertura-maven-plugin</artifactId>
         <version>2.7</version>
@@ -350,6 +310,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <skipITs>${skipIts}</skipITs>
+          <disableXmlReport>true</disableXmlReport>
+          <useFile>false</useFile>
+        </configuration>
         <executions>
           <execution>
             <goals>
@@ -358,11 +323,6 @@
             </goals>
           </execution>
         </executions>
-        <configuration>
-          <skipITs>${skipIts}</skipITs>
-          <disableXmlReport>true</disableXmlReport>
-          <useFile>false</useFile>
-        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractBucketLifecycleManager.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractBucketLifecycleManager.java
@@ -55,116 +55,107 @@ import jenkins.model.Jenkins;
  * @see com.google.jenkins.plugins.storage.ExpiringBucketLifecycleManager
  */
 public abstract class AbstractBucketLifecycleManager extends AbstractUpload {
-  /**
-   * Constructs the base bucket OLM plugin from the bucket name and module.
-   *
-   * @param bucket GCS Bucket in which to alter the time to live.
-   * @param module Helper class methods to use for execution.
-   */
-  public AbstractBucketLifecycleManager(String bucket, @Nullable UploadModule module) {
-    super(bucket, module);
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  @Nullable
-  protected final UploadSpec getInclusions(Run<?, ?> run, FilePath workspace, TaskListener listener)
-      throws UploadException {
-    // Return an empty list, we don't actually do any uploads.
-    return new UploadSpec(workspace, ImmutableList.<FilePath>of());
-  }
-
-  /**
-   * This overrides the core implementation to provide additional hooks for decorating storage
-   * objects with lifecycle annotations.
-   *
-   * @param credentials The credentials with which to fetch/create the bucket
-   * @param bucketName The top-level bucket name to ensure exists
-   * @return an instance of the named bucket, created or retrieved.
-   * @throws UploadException if any issues are encountered
-   */
-  @Override
-  protected Bucket getOrCreateBucket(
-      Storage service, GoogleRobotCredentials credentials, Executor executor, String bucketName)
-      throws UploadException {
-    try {
-      try {
-        try {
-          return checkBucket(
-              executor.execute(
-                  service
-                      .buckets()
-                      .get(bucketName)
-                      .setProjection("full"))); // to retrieve the bucket ACLs
-        } catch (NotFoundException e) {
-          try {
-            // This is roughly the opposite of how the command-line sample does
-            // things.  We do things this way to optimize for the case where the
-            // bucket already exists.
-            Bucket bucket = new Bucket().setName(bucketName);
-
-            // Annotate the bucket with our lifecycle properties.
-            bucket = decorateBucket(bucket);
-
-            bucket =
-                executor.execute(
-                    service
-                        .buckets()
-                        .insert(credentials.getProjectId(), bucket)
-                        .setProjection("full")); // to retrieve the bucket ACLs
-
-            return bucket;
-          } catch (ConflictException ex) {
-            // If we get back a "Conflict" response, it means that the bucket
-            // was inserted between when we first tried to get it and were able
-            // to successfully insert one.
-            // NOTE: This could be due to an initial insertion attempt
-            // succeeding but returning an exception, or a race with another
-            // service.
-            return checkBucket(
-                executor.execute(
-                    service
-                        .buckets()
-                        .get(bucketName)
-                        .setProjection("full"))); // to retrieve the bucket ACLs
-          }
-        }
-      } catch (InvalidAnnotationException nae) {
-        Bucket bucket = nae.getBucket();
-        bucket = decorateBucket(bucket);
-
-        // If it exists, but isn't annotated, then update it with the annotated
-        // version.
-        return executor.execute(service.buckets().update(bucketName, bucket).setProjection("full"));
-      }
-    } catch (ExecutorException e) {
-      throw new UploadException(Messages.AbstractUpload_ExceptionGetBucket(bucketName), e);
-    } catch (IOException e) {
-      throw new UploadException(Messages.AbstractUpload_ExceptionGetBucket(bucketName), e);
+    /**
+     * Constructs the base bucket OLM plugin from the bucket name and module.
+     *
+     * @param bucket GCS Bucket in which to alter the time to live.
+     * @param module Helper class methods to use for execution.
+     */
+    public AbstractBucketLifecycleManager(String bucket, @Nullable UploadModule module) {
+        super(bucket, module);
     }
-  }
 
-  /**
-   * This is intended to be an identity function that throws when the input is not adequately
-   * annotated.
-   *
-   * @param bucket the pre-existing bucket whose annotations to validate.
-   * @throws InvalidAnnotationException if not annotated properly.
-   * @return The bucket that was validated.
-   */
-  protected abstract Bucket checkBucket(Bucket bucket) throws InvalidAnnotationException;
+    /** {@inheritDoc} */
+    @Override
+    @Nullable
+    protected final UploadSpec getInclusions(Run<?, ?> run, FilePath workspace, TaskListener listener)
+            throws UploadException {
+        // Return an empty list, we don't actually do any uploads.
+        return new UploadSpec(workspace, ImmutableList.<FilePath>of());
+    }
 
-  /**
-   * A hook by which extensions may annotate a new or existing bucket.
-   *
-   * @param bucket The bucket to annotate and return.
-   * @return The bucket to annotate and return.
-   */
-  protected abstract Bucket decorateBucket(Bucket bucket);
+    /**
+     * This overrides the core implementation to provide additional hooks for decorating storage
+     * objects with lifecycle annotations.
+     *
+     * @param credentials The credentials with which to fetch/create the bucket
+     * @param bucketName The top-level bucket name to ensure exists
+     * @return an instance of the named bucket, created or retrieved.
+     * @throws UploadException if any issues are encountered
+     */
+    @Override
+    protected Bucket getOrCreateBucket(
+            Storage service, GoogleRobotCredentials credentials, Executor executor, String bucketName)
+            throws UploadException {
+        try {
+            try {
+                try {
+                    return checkBucket(executor.execute(
+                            service.buckets().get(bucketName).setProjection("full"))); // to retrieve the bucket ACLs
+                } catch (NotFoundException e) {
+                    try {
+                        // This is roughly the opposite of how the command-line sample does
+                        // things.  We do things this way to optimize for the case where the
+                        // bucket already exists.
+                        Bucket bucket = new Bucket().setName(bucketName);
 
-  /** {@inheritDoc} */
-  public AbstractBucketLifecycleManagerDescriptor getDescriptor() {
-    return (AbstractBucketLifecycleManagerDescriptor)
-        checkNotNull(Jenkins.get()).getDescriptor(getClass());
-  }
+                        // Annotate the bucket with our lifecycle properties.
+                        bucket = decorateBucket(bucket);
+
+                        bucket = executor.execute(service.buckets()
+                                .insert(credentials.getProjectId(), bucket)
+                                .setProjection("full")); // to retrieve the bucket ACLs
+
+                        return bucket;
+                    } catch (ConflictException ex) {
+                        // If we get back a "Conflict" response, it means that the bucket
+                        // was inserted between when we first tried to get it and were able
+                        // to successfully insert one.
+                        // NOTE: This could be due to an initial insertion attempt
+                        // succeeding but returning an exception, or a race with another
+                        // service.
+                        return checkBucket(executor.execute(service.buckets()
+                                .get(bucketName)
+                                .setProjection("full"))); // to retrieve the bucket ACLs
+                    }
+                }
+            } catch (InvalidAnnotationException nae) {
+                Bucket bucket = nae.getBucket();
+                bucket = decorateBucket(bucket);
+
+                // If it exists, but isn't annotated, then update it with the annotated
+                // version.
+                return executor.execute(
+                        service.buckets().update(bucketName, bucket).setProjection("full"));
+            }
+        } catch (ExecutorException e) {
+            throw new UploadException(Messages.AbstractUpload_ExceptionGetBucket(bucketName), e);
+        } catch (IOException e) {
+            throw new UploadException(Messages.AbstractUpload_ExceptionGetBucket(bucketName), e);
+        }
+    }
+
+    /**
+     * This is intended to be an identity function that throws when the input is not adequately
+     * annotated.
+     *
+     * @param bucket the pre-existing bucket whose annotations to validate.
+     * @throws InvalidAnnotationException if not annotated properly.
+     * @return The bucket that was validated.
+     */
+    protected abstract Bucket checkBucket(Bucket bucket) throws InvalidAnnotationException;
+
+    /**
+     * A hook by which extensions may annotate a new or existing bucket.
+     *
+     * @param bucket The bucket to annotate and return.
+     * @return The bucket to annotate and return.
+     */
+    protected abstract Bucket decorateBucket(Bucket bucket);
+
+    /** {@inheritDoc} */
+    public AbstractBucketLifecycleManagerDescriptor getDescriptor() {
+        return (AbstractBucketLifecycleManagerDescriptor)
+                checkNotNull(Jenkins.get()).getDescriptor(getClass());
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractBucketLifecycleManagerDescriptor.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractBucketLifecycleManagerDescriptor.java
@@ -22,31 +22,29 @@ import org.kohsuke.stapler.QueryParameter;
 
 /** The descriptor for our new {@link AbstractBucketLifecycleManager} extension point. */
 public abstract class AbstractBucketLifecycleManagerDescriptor extends AbstractUploadDescriptor {
-  public AbstractBucketLifecycleManagerDescriptor(
-      Class<? extends AbstractBucketLifecycleManager> clazz) {
-    super(clazz);
-  }
-
-  /**
-   * This specialized override of the bucket name form validation disallows multi-part storage
-   * prefixes (just the bucket name).
-   */
-  @Override
-  public FormValidation doCheckBucketNameWithVars(@QueryParameter final String bucketNameWithVars)
-      throws IOException {
-    String resolvedInput = Resolve.resolveBuiltin(bucketNameWithVars);
-    if (!resolvedInput.startsWith(GCS_SCHEME)) {
-      return FormValidation.error(
-          Messages.AbstractUploadDescriptor_BadPrefix(resolvedInput, GCS_SCHEME));
-    }
-    // Lop off the prefix.
-    resolvedInput = resolvedInput.substring(GCS_SCHEME.length());
-
-    if (resolvedInput.contains("/")) {
-      return FormValidation.error(
-          Messages.AbstractBucketLifecycleManagerDescriptor_MultiPartBucket(resolvedInput));
+    public AbstractBucketLifecycleManagerDescriptor(Class<? extends AbstractBucketLifecycleManager> clazz) {
+        super(clazz);
     }
 
-    return super.doCheckBucketNameWithVars(bucketNameWithVars);
-  }
+    /**
+     * This specialized override of the bucket name form validation disallows multi-part storage
+     * prefixes (just the bucket name).
+     */
+    @Override
+    public FormValidation doCheckBucketNameWithVars(@QueryParameter final String bucketNameWithVars)
+            throws IOException {
+        String resolvedInput = Resolve.resolveBuiltin(bucketNameWithVars);
+        if (!resolvedInput.startsWith(GCS_SCHEME)) {
+            return FormValidation.error(Messages.AbstractUploadDescriptor_BadPrefix(resolvedInput, GCS_SCHEME));
+        }
+        // Lop off the prefix.
+        resolvedInput = resolvedInput.substring(GCS_SCHEME.length());
+
+        if (resolvedInput.contains("/")) {
+            return FormValidation.error(
+                    Messages.AbstractBucketLifecycleManagerDescriptor_MultiPartBucket(resolvedInput));
+        }
+
+        return super.doCheckBucketNameWithVars(bucketNameWithVars);
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractUpload.java
@@ -91,581 +91,548 @@ import org.kohsuke.stapler.DataBoundSetter;
  *     </ul>
  */
 // TODO: Refactor to use StorageClient https://github.com/jenkinsci/google-storage-plugin/issues/71
-public abstract class AbstractUpload
-    implements Describable<AbstractUpload>, ExtensionPoint, Serializable {
-  private static final Logger logger = Logger.getLogger(AbstractUpload.class.getName());
-  private static final Map<String, String> CONTENT_TYPES =
-      Stream.of(
-              new String[][] {
+public abstract class AbstractUpload implements Describable<AbstractUpload>, ExtensionPoint, Serializable {
+    private static final Logger logger = Logger.getLogger(AbstractUpload.class.getName());
+    private static final Map<String, String> CONTENT_TYPES = Stream.of(new String[][] {
                 {"css", "text/css"},
                 {"js", "application/javascript"},
                 {"svg", "image/svg+xml"},
                 {"woff2", "font/woff2"}
-              })
-          .collect(
-              Collectors.collectingAndThen(
-                  Collectors.toMap(data -> data[0], data -> data[1]),
-                  Collections::<String, String>unmodifiableMap));
-  private String pathPrefix;
-  // The module to use for providing dependencies.
-  private final transient UploadModule module;
-  // NOTE: old name kept for deserialization
-  private final String bucketNameWithVars;
-  private boolean sharedPublicly;
-  private boolean forFailedJobs;
-  private boolean showInline;
+            })
+            .collect(Collectors.collectingAndThen(
+                    Collectors.toMap(data -> data[0], data -> data[1]), Collections::<String, String>unmodifiableMap));
+    private String pathPrefix;
+    // The module to use for providing dependencies.
+    private final transient UploadModule module;
+    // NOTE: old name kept for deserialization
+    private final String bucketNameWithVars;
+    private boolean sharedPublicly;
+    private boolean forFailedJobs;
+    private boolean showInline;
 
-  /**
-   * Construct the base upload from a handful of universal properties.
-   *
-   * @param bucket The unresolved name of the storage bucket within which to store the resulting
-   *     objects.
-   * @param module An {@link UploadModule} to use for execution.
-   */
-  public AbstractUpload(String bucket, @Nullable UploadModule module) {
-    if (module != null) {
-      this.module = module;
-    } else {
-      this.module = new UploadModule();
-    }
-    this.bucketNameWithVars = checkNotNull(bucket);
-  }
-
-  /**
-   * This method allows the old signature for compatibility reasons. Calls {@link #perform(String,
-   * Run, FilePath, TaskListener)}.
-   *
-   * @param credentialsId The unique ID for the credentials we are using to authenticate with GCS.
-   * @param build Current build being run.
-   * @param listener Listener for events of this job.
-   * @throws UploadException If there was an issue uploading/accessing the GCS API.
-   * @throws IOException If there was issue authenticating with credentialsId.
-   */
-  public final void perform(String credentialsId, AbstractBuild<?, ?> build, TaskListener listener)
-      throws UploadException, IOException {
-    perform(credentialsId, build, build.getWorkspace(), listener);
-  }
-
-  /**
-   * The main action entry point of this extension. This uploads the contents included by the
-   * implementation to our resolved storage bucket.
-   *
-   * @param credentialsId The unique ID for the credentials we are using to authenticate with GCS.
-   * @param run Current job being run.
-   * @param workspace Workspace of node running the job.
-   * @param listener Listener for events of this job.
-   * @throws UploadException If there was an issue uploading/accessing the GCS API.
-   * @throws IOException If there was issue authenticating with credentialsId.
-   */
-  public final void perform(
-      String credentialsId, Run<?, ?> run, FilePath workspace, TaskListener listener)
-      throws UploadException, IOException {
-    GoogleRobotCredentials credentials = StorageUtil.lookupCredentials(credentialsId);
-
-    if (!forResult(run.getResult())) {
-      // Don't upload for the given build state.
-      return;
-    }
-
-    try {
-      // Turn paths containing things like $BUILD_NUMBER and $JOB_NAME into
-      // their fully resolved forms.
-      String resolvedBucket = StorageUtil.replaceMacro(getBucket(), run, listener);
-      BucketPath storagePrefix = new BucketPath(resolvedBucket);
-
-      UploadSpec uploads = getInclusions(run, checkNotNull(workspace), listener);
-
-      if (uploads != null) {
-        BuildGcsUploadReport links = BuildGcsUploadReport.of(run);
-        links.addBucket(storagePrefix.getBucket());
-
-        initiateUploadsAtWorkspace(credentials, run, storagePrefix, uploads, listener);
-      }
-    } catch (InterruptedException e) {
-      throw new UploadException(Messages.AbstractUpload_UploadException(), e);
-    } catch (IOException e) {
-      throw new UploadException(Messages.AbstractUpload_UploadException(), e);
-    }
-  }
-
-  /**
-   * This tuple is used to return the modified workspace and collection of {@link FilePath}s to
-   * upload to {@link #perform}.
-   *
-   * <p>NOTE: The workspace is simply used to determine the path the object will be stored in
-   * relative to the bucket. If it is relative to the workspace, that relative path will be appended
-   * to the storage prefix. If it is not, then the absolute path will be appended.
-   */
-  protected static class UploadSpec implements Serializable {
-
-    public UploadSpec(FilePath workspace, List<FilePath> inclusions) {
-      this.workspace = checkNotNull(workspace);
-      this.inclusions = Collections.unmodifiableCollection(inclusions);
-    }
-
-    public final FilePath workspace;
-    public final Collection<FilePath> inclusions;
-  }
-
-  /**
-   * Implementations override this interface in order to surface the set of {@link FilePath}s the
-   * core logic should upload.
-   *
-   * @see UploadSpec for further details.
-   * @param run Current job being run.
-   * @param workspace Workspace of node running the job.
-   * @param listener Listener for events of this job.
-   * @return Set of {@link FilePath}s to upload.
-   * @throws UploadException If there was an issue fetching the inclusions.
-   */
-  @Nullable
-  protected abstract UploadSpec getInclusions(
-      Run<?, ?> run, FilePath workspace, TaskListener listener) throws UploadException;
-
-  /**
-   * This hook is intended to give implementations the opportunity to further annotate the {@link
-   * StorageObject} with metadata before uploading it to cloud storage.
-   *
-   * <p>NOTE: The base implementation does not do anything, so calling {@code
-   * super.annotateObject()} is unnecessary.
-   *
-   * @param object GCS object to annotate.
-   * @param listener Listener for events of this job.
-   * @throws UploadException If there was an issue annotating the object with metadata.
-   */
-  protected void annotateObject(StorageObject object, TaskListener listener)
-      throws UploadException {
-    ;
-  }
-
-  /**
-   * Retrieves the metadata to attach to the storage object.
-   *
-   * <p>NOTE: This can be overriden to surface additional (or less) information.
-   *
-   * @param run Current job being run.
-   * @return Metadata in key-value form.
-   */
-  protected Map<String, String> getMetadata(Run<?, ?> run) {
-    return MetadataContainer.of(run).getSerializedMetadata();
-  }
-
-  /**
-   * Determine whether we should upload the pattern for the given build result.
-   *
-   * @param result Result of the build run.
-   * @return Whether we should upload the pattern for the given build result.
-   */
-  public boolean forResult(Result result) {
-    if (result == null) {
-      // We might have unfinished builds, e.g., through pipeline of Build Step.
-      // Always run for those.
-      return true;
-    }
-    if (result == Result.SUCCESS) {
-      // We always run on successful builds.
-      return true;
-    }
-    if (result == Result.FAILURE || result == Result.UNSTABLE) {
-      return isForFailedJobs();
-    }
-    // else NOT_BUILT
-    return false;
-  }
-
-  /**
-   * @return Provide detail information summarizing this download for the GCS upload report.
-   */
-  public abstract String getDetails();
-
-  /**
-   * @return The {@link UploadModule} for providing dependencies.
-   */
-  protected synchronized UploadModule getModule() {
-    if (this.module == null) {
-      return new UploadModule();
-    }
-    return this.module;
-  }
-  /**
-   * @return The bucket name specified by the user, which potentially contains unresolved symbols,
-   *     such as $JOB_NAME and $BUILD_NUMBER.
-   */
-  public String getBucket() {
-    return bucketNameWithVars;
-  }
-
-  /**
-   * @param sharedPublicly Whether to surface the file being uploaded to anyone with the link.
-   */
-  @DataBoundSetter
-  public void setSharedPublicly(boolean sharedPublicly) {
-    this.sharedPublicly = sharedPublicly;
-  }
-
-  /**
-   * @return Whether to surface the file being uploaded to anyone with the link.
-   */
-  public boolean isSharedPublicly() {
-    return sharedPublicly;
-  }
-
-  /**
-   * @param forFailedJobs Whether to attempt the upload, even if the job failed.
-   */
-  @DataBoundSetter
-  public void setForFailedJobs(boolean forFailedJobs) {
-    this.forFailedJobs = forFailedJobs;
-  }
-
-  /**
-   * @return Whether to attempt the upload, even if the job failed.
-   */
-  public boolean isForFailedJobs() {
-    return forFailedJobs;
-  }
-
-  /**
-   * @param showInline Set whether to indicate in metadata that the file should be viewable inline
-   *     in web browsers, rather than requiring it to be downloaded first.
-   */
-  @DataBoundSetter
-  public void setShowInline(boolean showInline) {
-    this.showInline = showInline;
-  }
-
-  /**
-   * @return Whether to indicate in metadata that the file should be viewable inline in web
-   *     browsers, rather than requiring it to be downloaded first.
-   */
-  public boolean isShowInline() {
-    return showInline;
-  }
-
-  /**
-   * @param pathPrefix The path prefix that will be stripped from uploaded files. May be null if no
-   *     path prefix needs to be stripped.
-   *     <p>Filenames that do not start with this prefix will not be modified. Trailing slash is
-   *     automatically added if it is missing.
-   */
-  @DataBoundSetter
-  public void setPathPrefix(@Nullable String pathPrefix) {
-    if (pathPrefix != null && !pathPrefix.endsWith("/")) {
-      pathPrefix += "/";
-    }
-    this.pathPrefix = pathPrefix;
-  }
-
-  /**
-   * @return The path prefix that will be stripped from uploaded files. May be null if no path
-   *     prefix needs to be stripped.
-   *     <p>Filenames that do not start with this prefix will not be modified. Trailing slash is
-   *     automatically added if it is missing.
-   */
-  @Nullable
-  public String getPathPrefix() {
-    return pathPrefix;
-  }
-
-  /**
-   * Gives all registered {@link AbstractUpload}s. See:
-   * https://wiki.jenkins-ci.org/display/JENKINS/Defining+a+new+extension+point
-   *
-   * @return All registered {@link AbstractUpload}s.
-   */
-  public static DescriptorExtensionList<AbstractUpload, AbstractUploadDescriptor> all() {
-    return checkNotNull(Jenkins.get()).getDescriptorList(AbstractUpload.class);
-  }
-
-  /** {@inheritDoc} */
-  public AbstractUploadDescriptor getDescriptor() {
-    return (AbstractUploadDescriptor) checkNotNull(Jenkins.get()).getDescriptor(getClass());
-  }
-
-  /**
-   * Execute the {@link UploadSpec} for this {@code build} to the bucket specified by {@code
-   * storagePrefix} using the authority of {@code credentials} and logging any information to {@code
-   * listener}.
-   *
-   * @throws UploadException If there was any issue during upload.
-   */
-  private void initiateUploadsAtWorkspace(
-      final GoogleRobotCredentials credentials,
-      final Run run,
-      final BucketPath storagePrefix,
-      final UploadSpec uploads,
-      final TaskListener listener)
-      throws UploadException {
-    try {
-      try {
-        // Use remotable credential to access the storage service from the
-        // remote machine.
-        final GoogleRobotCredentials remoteCredentials =
-            checkNotNull(credentials).forRemote(getModule().getRequirement());
-        final String version = getModule().getVersion();
-
-        uploads.workspace.act(
-            new MasterToSlaveCallable<Void, UploadException>() {
-              @Override
-              public Void call() throws UploadException {
-                performUploads(
-                    storagePrefix.getBucket(),
-                    storagePrefix.getObject(),
-                    remoteCredentials,
-                    uploads,
-                    listener,
-                    version);
-                return (Void) null;
-              }
-            });
-      } catch (GeneralSecurityException e) {
-        throw new UploadException(Messages.AbstractUpload_RemoteCredentialError(), e);
-      }
-
-      // We can't do this over the wire, so do it in bulk here
-      BuildGcsUploadReport report = BuildGcsUploadReport.of(run);
-      for (FilePath include : uploads.inclusions) {
-        report.addUpload(
-            StorageUtil.getStrippedFilename(
-                StorageUtil.getRelative(include, uploads.workspace), pathPrefix),
-            storagePrefix);
-      }
-
-    } catch (IOException e) {
-      throw new UploadException(Messages.AbstractUpload_ExceptionFileUpload(), e);
-    } catch (InterruptedException e) {
-      throw new UploadException(Messages.AbstractUpload_ExceptionFileUpload(), e);
-    }
-  }
-
-  /**
-   * This is the workhorse API for performing the actual uploads. It is performed at the workspace,
-   * so that all of the {@link FilePath}s should be local.
-   */
-  private void performUploads(
-      final String bucketName,
-      final String objectPrefix,
-      final GoogleRobotCredentials credentials,
-      final UploadSpec uploads,
-      final TaskListener listener,
-      final String version)
-      throws UploadException {
-    RepeatOperation<UploadException> a =
-        new RepeatOperation<UploadException>() {
-          private final Queue<FilePath> paths = new LinkedList<>(uploads.inclusions);
-          private final Executor executor = getModule().newExecutor();
-
-          private Storage service;
-          private Bucket bucket;
-
-          @Override
-          public void initCredentials() throws UploadException, IOException {
-            service = getModule().getStorageService(credentials, version);
-            // Ensure the bucket exists, fetching it regardless so that we can
-            // attach its default ACLs to the objects we upload.
-            bucket = getOrCreateBucket(service, credentials, executor, bucketName);
-          }
-
-          @Override
-          public void act()
-              throws UploadException, IOException, InterruptedException, ExecutorException {
-            FilePath include = paths.peek();
-            if (include == null) {
-              return;
-            }
-            String relativePath = StorageUtil.getRelative(include, uploads.workspace);
-            String uploadedFileName = StorageUtil.getStrippedFilename(relativePath, pathPrefix);
-            String finalName =
-                FilenameUtils.separatorsToUnix(
-                    FilenameUtils.concat(objectPrefix, uploadedFileName));
-
-            StorageObject object =
-                new StorageObject()
-                    .setName(finalName)
-                    .setContentDisposition(
-                        HttpHeaders.getContentDisposition(include.getName(), isShowInline()))
-                    .setContentType(detectMIMEType(include.getName()))
-                    .setSize(BigInteger.valueOf(include.length()));
-
-            if (isSharedPublicly()) {
-              object.setAcl(addPublicReadAccess(getDefaultObjectAcl(bucket, listener)));
-            }
-
-            // Give clients an opportunity to decorate the storage
-            // object before we store it.
-            annotateObject(object, listener);
-
-            // Log that we are uploading the file and begin executing the upload.
-            listener
-                .getLogger()
-                .println(getModule().prefix(Messages.AbstractUpload_Uploading(relativePath)));
-
-            performUploadWithRetry(executor, service, bucket, object, include);
-            paths.remove(include);
-          }
-
-          @Override
-          public boolean moreWork() {
-            return !paths.isEmpty();
-          }
-        };
-
-    try {
-      RetryStorageOperation.performRequestWithReinitCredentials(a);
-    } catch (ForbiddenException e) {
-      // If the user doesn't own a bucket then they will end up here.
-      throw new UploadException(Messages.AbstractUpload_ForbiddenFileUpload(), e);
-    } catch (ExecutorException e) {
-      throw new UploadException(Messages.AbstractUpload_ExceptionFileUpload(), e);
-    } catch (IOException e) {
-      throw new UploadException(Messages.AbstractUpload_ExceptionFileUpload(), e);
-    } catch (InterruptedException e) {
-      throw new UploadException(Messages.AbstractUpload_ExceptionFileUpload(), e);
-    }
-  }
-
-  /**
-   * Auxiliar method for detecting web-related filename extensions, so setting correctly
-   * Content-Type.
-   */
-  private String detectMIMEType(String filename) {
-    String extension = Files.getFileExtension(filename);
-    if (CONTENT_TYPES.containsKey(extension)) {
-      return CONTENT_TYPES.get(extension);
-    } else {
-      return URLConnection.guessContentTypeFromName(filename);
-    }
-  }
-
-  /**
-   * We need our own storage retry logic because we must recreate the input stream for the media
-   * uploader.
-   */
-  private void performUploadWithRetry(
-      final Executor executor,
-      final Storage service,
-      final Bucket bucket,
-      final StorageObject object,
-      final FilePath include)
-      throws ExecutorException, IOException, InterruptedException {
-    Operation a =
-        new Operation() {
-          public void act() throws IOException, InterruptedException, ExecutorException {
-            // Create the insertion operation with the decorated object and
-            // an input stream of the file contents.
-            try (InputStream is = include.read()) {
-              Storage.Objects.Insert insertion =
-                  service
-                      .objects()
-                      .insert(
-                          bucket.getName(),
-                          object,
-                          new InputStreamContent(object.getContentType(), is));
-
-              // Make the operation non-resumable because we have seen a dramatic
-              // (e.g. 1000x) speedup from this.
-              MediaHttpUploader mediaUploader = insertion.getMediaHttpUploader();
-              if (mediaUploader != null) {
-                mediaUploader.setDirectUploadEnabled(true);
-              }
-              executor.execute(insertion);
-            }
-          }
-        };
-
-    RetryStorageOperation.performRequestWithRetry(executor, a, getModule().getInsertRetryCount());
-  }
-
-  // Fetch the default object ACL for this bucket. Return an empty list if
-  // we cannot.
-  private static List<ObjectAccessControl> getDefaultObjectAcl(
-      Bucket bucket, TaskListener listener) {
-    List<ObjectAccessControl> defaultAcl = bucket.getDefaultObjectAcl();
-    if (defaultAcl == null) {
-      listener.error(Messages.AbstractUpload_BucketObjectAclsError(bucket.getName()));
-      return ImmutableList.of();
-    } else {
-      return defaultAcl;
-    }
-  }
-
-  // Add public access to a given access control list
-  private static List<ObjectAccessControl> addPublicReadAccess(
-      List<ObjectAccessControl> defaultAcl) {
-    List<ObjectAccessControl> acl = Lists.newArrayList(defaultAcl);
-    final String publicEntity = "allUsers";
-    boolean alreadyShared =
-        Iterables.tryFind(
-                acl,
-                new Predicate<ObjectAccessControl>() {
-                  @Override
-                  public boolean apply(ObjectAccessControl access) {
-                    if (access != null) {
-                      return Objects.equal(access.getEntity(), publicEntity);
-                    } else {
-                      throw new NullPointerException(Messages.AbstractUpload_NullAccessError());
-                    }
-                  }
-                })
-            .isPresent();
-    /* If the entity 'allUsers' didn't already has READER or OWNER access, grant
-    READER. This is to avoid having both an OWNER record and a READER record
-    for that same entity */
-    if (!alreadyShared) {
-      acl.add(new ObjectAccessControl().setEntity("allUsers").setRole("READER"));
-    }
-    return acl;
-  }
-
-  /**
-   * Fetches or creates an instance of the bucket with the given name with the specified storage
-   * service.
-   *
-   * @param service Handle to the GCS API.
-   * @param credentials The credentials with which to fetch/create the bucket
-   * @param executor Helper class to make calls to the GCS API.
-   * @param bucketName The top-level bucket name to ensure exists
-   * @return an instance of the named bucket, created or retrieved.
-   * @throws UploadException if any issues are encountered
-   */
-  protected Bucket getOrCreateBucket(
-      Storage service, GoogleRobotCredentials credentials, Executor executor, String bucketName)
-      throws UploadException {
-    try {
-      try {
-        return executor.execute(
-            service.buckets().get(bucketName).setProjection("full")); // to retrieve the bucket ACLs
-      } catch (NotFoundException e) {
-        try {
-          // This is roughly the opposite of how the command-line sample does
-          // things.  We do things this way to optimize for the case where the
-          // bucket already exists.
-          Bucket bucket = new Bucket().setName(bucketName);
-          bucket =
-              executor.execute(
-                  service
-                      .buckets()
-                      .insert(credentials.getProjectId(), bucket)
-                      .setProjection("full")); // to retrieve the bucket ACLs
-
-          return bucket;
-        } catch (ConflictException ex) {
-          // If we get back a "Conflict" response, it means that the bucket
-          // was inserted between when we first tried to get it and were able
-          // to successfully insert one.
-          // NOTE: This could be due to an initial insertion attempt succeeding
-          // but returning an exception, or a race with another service.
-          return executor.execute(
-              service
-                  .buckets()
-                  .get(bucketName)
-                  .setProjection("full")); // to retrieve the bucket ACLs
+    /**
+     * Construct the base upload from a handful of universal properties.
+     *
+     * @param bucket The unresolved name of the storage bucket within which to store the resulting
+     *     objects.
+     * @param module An {@link UploadModule} to use for execution.
+     */
+    public AbstractUpload(String bucket, @Nullable UploadModule module) {
+        if (module != null) {
+            this.module = module;
+        } else {
+            this.module = new UploadModule();
         }
-      }
-    } catch (ExecutorException e) {
-      throw new UploadException(Messages.AbstractUpload_ExceptionGetBucket(bucketName), e);
-    } catch (IOException e) {
-      throw new UploadException(Messages.AbstractUpload_ExceptionGetBucket(bucketName), e);
+        this.bucketNameWithVars = checkNotNull(bucket);
     }
-  }
+
+    /**
+     * This method allows the old signature for compatibility reasons. Calls {@link #perform(String,
+     * Run, FilePath, TaskListener)}.
+     *
+     * @param credentialsId The unique ID for the credentials we are using to authenticate with GCS.
+     * @param build Current build being run.
+     * @param listener Listener for events of this job.
+     * @throws UploadException If there was an issue uploading/accessing the GCS API.
+     * @throws IOException If there was issue authenticating with credentialsId.
+     */
+    public final void perform(String credentialsId, AbstractBuild<?, ?> build, TaskListener listener)
+            throws UploadException, IOException {
+        perform(credentialsId, build, build.getWorkspace(), listener);
+    }
+
+    /**
+     * The main action entry point of this extension. This uploads the contents included by the
+     * implementation to our resolved storage bucket.
+     *
+     * @param credentialsId The unique ID for the credentials we are using to authenticate with GCS.
+     * @param run Current job being run.
+     * @param workspace Workspace of node running the job.
+     * @param listener Listener for events of this job.
+     * @throws UploadException If there was an issue uploading/accessing the GCS API.
+     * @throws IOException If there was issue authenticating with credentialsId.
+     */
+    public final void perform(String credentialsId, Run<?, ?> run, FilePath workspace, TaskListener listener)
+            throws UploadException, IOException {
+        GoogleRobotCredentials credentials = StorageUtil.lookupCredentials(credentialsId);
+
+        if (!forResult(run.getResult())) {
+            // Don't upload for the given build state.
+            return;
+        }
+
+        try {
+            // Turn paths containing things like $BUILD_NUMBER and $JOB_NAME into
+            // their fully resolved forms.
+            String resolvedBucket = StorageUtil.replaceMacro(getBucket(), run, listener);
+            BucketPath storagePrefix = new BucketPath(resolvedBucket);
+
+            UploadSpec uploads = getInclusions(run, checkNotNull(workspace), listener);
+
+            if (uploads != null) {
+                BuildGcsUploadReport links = BuildGcsUploadReport.of(run);
+                links.addBucket(storagePrefix.getBucket());
+
+                initiateUploadsAtWorkspace(credentials, run, storagePrefix, uploads, listener);
+            }
+        } catch (InterruptedException e) {
+            throw new UploadException(Messages.AbstractUpload_UploadException(), e);
+        } catch (IOException e) {
+            throw new UploadException(Messages.AbstractUpload_UploadException(), e);
+        }
+    }
+
+    /**
+     * This tuple is used to return the modified workspace and collection of {@link FilePath}s to
+     * upload to {@link #perform}.
+     *
+     * <p>NOTE: The workspace is simply used to determine the path the object will be stored in
+     * relative to the bucket. If it is relative to the workspace, that relative path will be appended
+     * to the storage prefix. If it is not, then the absolute path will be appended.
+     */
+    protected static class UploadSpec implements Serializable {
+
+        public UploadSpec(FilePath workspace, List<FilePath> inclusions) {
+            this.workspace = checkNotNull(workspace);
+            this.inclusions = Collections.unmodifiableCollection(inclusions);
+        }
+
+        public final FilePath workspace;
+        public final Collection<FilePath> inclusions;
+    }
+
+    /**
+     * Implementations override this interface in order to surface the set of {@link FilePath}s the
+     * core logic should upload.
+     *
+     * @see UploadSpec for further details.
+     * @param run Current job being run.
+     * @param workspace Workspace of node running the job.
+     * @param listener Listener for events of this job.
+     * @return Set of {@link FilePath}s to upload.
+     * @throws UploadException If there was an issue fetching the inclusions.
+     */
+    @Nullable
+    protected abstract UploadSpec getInclusions(Run<?, ?> run, FilePath workspace, TaskListener listener)
+            throws UploadException;
+
+    /**
+     * This hook is intended to give implementations the opportunity to further annotate the {@link
+     * StorageObject} with metadata before uploading it to cloud storage.
+     *
+     * <p>NOTE: The base implementation does not do anything, so calling {@code
+     * super.annotateObject()} is unnecessary.
+     *
+     * @param object GCS object to annotate.
+     * @param listener Listener for events of this job.
+     * @throws UploadException If there was an issue annotating the object with metadata.
+     */
+    protected void annotateObject(StorageObject object, TaskListener listener) throws UploadException {
+        ;
+    }
+
+    /**
+     * Retrieves the metadata to attach to the storage object.
+     *
+     * <p>NOTE: This can be overriden to surface additional (or less) information.
+     *
+     * @param run Current job being run.
+     * @return Metadata in key-value form.
+     */
+    protected Map<String, String> getMetadata(Run<?, ?> run) {
+        return MetadataContainer.of(run).getSerializedMetadata();
+    }
+
+    /**
+     * Determine whether we should upload the pattern for the given build result.
+     *
+     * @param result Result of the build run.
+     * @return Whether we should upload the pattern for the given build result.
+     */
+    public boolean forResult(Result result) {
+        if (result == null) {
+            // We might have unfinished builds, e.g., through pipeline of Build Step.
+            // Always run for those.
+            return true;
+        }
+        if (result == Result.SUCCESS) {
+            // We always run on successful builds.
+            return true;
+        }
+        if (result == Result.FAILURE || result == Result.UNSTABLE) {
+            return isForFailedJobs();
+        }
+        // else NOT_BUILT
+        return false;
+    }
+
+    /**
+     * @return Provide detail information summarizing this download for the GCS upload report.
+     */
+    public abstract String getDetails();
+
+    /**
+     * @return The {@link UploadModule} for providing dependencies.
+     */
+    protected synchronized UploadModule getModule() {
+        if (this.module == null) {
+            return new UploadModule();
+        }
+        return this.module;
+    }
+    /**
+     * @return The bucket name specified by the user, which potentially contains unresolved symbols,
+     *     such as $JOB_NAME and $BUILD_NUMBER.
+     */
+    public String getBucket() {
+        return bucketNameWithVars;
+    }
+
+    /**
+     * @param sharedPublicly Whether to surface the file being uploaded to anyone with the link.
+     */
+    @DataBoundSetter
+    public void setSharedPublicly(boolean sharedPublicly) {
+        this.sharedPublicly = sharedPublicly;
+    }
+
+    /**
+     * @return Whether to surface the file being uploaded to anyone with the link.
+     */
+    public boolean isSharedPublicly() {
+        return sharedPublicly;
+    }
+
+    /**
+     * @param forFailedJobs Whether to attempt the upload, even if the job failed.
+     */
+    @DataBoundSetter
+    public void setForFailedJobs(boolean forFailedJobs) {
+        this.forFailedJobs = forFailedJobs;
+    }
+
+    /**
+     * @return Whether to attempt the upload, even if the job failed.
+     */
+    public boolean isForFailedJobs() {
+        return forFailedJobs;
+    }
+
+    /**
+     * @param showInline Set whether to indicate in metadata that the file should be viewable inline
+     *     in web browsers, rather than requiring it to be downloaded first.
+     */
+    @DataBoundSetter
+    public void setShowInline(boolean showInline) {
+        this.showInline = showInline;
+    }
+
+    /**
+     * @return Whether to indicate in metadata that the file should be viewable inline in web
+     *     browsers, rather than requiring it to be downloaded first.
+     */
+    public boolean isShowInline() {
+        return showInline;
+    }
+
+    /**
+     * @param pathPrefix The path prefix that will be stripped from uploaded files. May be null if no
+     *     path prefix needs to be stripped.
+     *     <p>Filenames that do not start with this prefix will not be modified. Trailing slash is
+     *     automatically added if it is missing.
+     */
+    @DataBoundSetter
+    public void setPathPrefix(@Nullable String pathPrefix) {
+        if (pathPrefix != null && !pathPrefix.endsWith("/")) {
+            pathPrefix += "/";
+        }
+        this.pathPrefix = pathPrefix;
+    }
+
+    /**
+     * @return The path prefix that will be stripped from uploaded files. May be null if no path
+     *     prefix needs to be stripped.
+     *     <p>Filenames that do not start with this prefix will not be modified. Trailing slash is
+     *     automatically added if it is missing.
+     */
+    @Nullable
+    public String getPathPrefix() {
+        return pathPrefix;
+    }
+
+    /**
+     * Gives all registered {@link AbstractUpload}s. See:
+     * https://wiki.jenkins-ci.org/display/JENKINS/Defining+a+new+extension+point
+     *
+     * @return All registered {@link AbstractUpload}s.
+     */
+    public static DescriptorExtensionList<AbstractUpload, AbstractUploadDescriptor> all() {
+        return checkNotNull(Jenkins.get()).getDescriptorList(AbstractUpload.class);
+    }
+
+    /** {@inheritDoc} */
+    public AbstractUploadDescriptor getDescriptor() {
+        return (AbstractUploadDescriptor) checkNotNull(Jenkins.get()).getDescriptor(getClass());
+    }
+
+    /**
+     * Execute the {@link UploadSpec} for this {@code build} to the bucket specified by {@code
+     * storagePrefix} using the authority of {@code credentials} and logging any information to {@code
+     * listener}.
+     *
+     * @throws UploadException If there was any issue during upload.
+     */
+    private void initiateUploadsAtWorkspace(
+            final GoogleRobotCredentials credentials,
+            final Run run,
+            final BucketPath storagePrefix,
+            final UploadSpec uploads,
+            final TaskListener listener)
+            throws UploadException {
+        try {
+            try {
+                // Use remotable credential to access the storage service from the
+                // remote machine.
+                final GoogleRobotCredentials remoteCredentials =
+                        checkNotNull(credentials).forRemote(getModule().getRequirement());
+                final String version = getModule().getVersion();
+
+                uploads.workspace.act(new MasterToSlaveCallable<Void, UploadException>() {
+                    @Override
+                    public Void call() throws UploadException {
+                        performUploads(
+                                storagePrefix.getBucket(),
+                                storagePrefix.getObject(),
+                                remoteCredentials,
+                                uploads,
+                                listener,
+                                version);
+                        return (Void) null;
+                    }
+                });
+            } catch (GeneralSecurityException e) {
+                throw new UploadException(Messages.AbstractUpload_RemoteCredentialError(), e);
+            }
+
+            // We can't do this over the wire, so do it in bulk here
+            BuildGcsUploadReport report = BuildGcsUploadReport.of(run);
+            for (FilePath include : uploads.inclusions) {
+                report.addUpload(
+                        StorageUtil.getStrippedFilename(
+                                StorageUtil.getRelative(include, uploads.workspace), pathPrefix),
+                        storagePrefix);
+            }
+
+        } catch (IOException e) {
+            throw new UploadException(Messages.AbstractUpload_ExceptionFileUpload(), e);
+        } catch (InterruptedException e) {
+            throw new UploadException(Messages.AbstractUpload_ExceptionFileUpload(), e);
+        }
+    }
+
+    /**
+     * This is the workhorse API for performing the actual uploads. It is performed at the workspace,
+     * so that all of the {@link FilePath}s should be local.
+     */
+    private void performUploads(
+            final String bucketName,
+            final String objectPrefix,
+            final GoogleRobotCredentials credentials,
+            final UploadSpec uploads,
+            final TaskListener listener,
+            final String version)
+            throws UploadException {
+        RepeatOperation<UploadException> a = new RepeatOperation<UploadException>() {
+            private final Queue<FilePath> paths = new LinkedList<>(uploads.inclusions);
+            private final Executor executor = getModule().newExecutor();
+
+            private Storage service;
+            private Bucket bucket;
+
+            @Override
+            public void initCredentials() throws UploadException, IOException {
+                service = getModule().getStorageService(credentials, version);
+                // Ensure the bucket exists, fetching it regardless so that we can
+                // attach its default ACLs to the objects we upload.
+                bucket = getOrCreateBucket(service, credentials, executor, bucketName);
+            }
+
+            @Override
+            public void act() throws UploadException, IOException, InterruptedException, ExecutorException {
+                FilePath include = paths.peek();
+                if (include == null) {
+                    return;
+                }
+                String relativePath = StorageUtil.getRelative(include, uploads.workspace);
+                String uploadedFileName = StorageUtil.getStrippedFilename(relativePath, pathPrefix);
+                String finalName = FilenameUtils.separatorsToUnix(FilenameUtils.concat(objectPrefix, uploadedFileName));
+
+                StorageObject object = new StorageObject()
+                        .setName(finalName)
+                        .setContentDisposition(HttpHeaders.getContentDisposition(include.getName(), isShowInline()))
+                        .setContentType(detectMIMEType(include.getName()))
+                        .setSize(BigInteger.valueOf(include.length()));
+
+                if (isSharedPublicly()) {
+                    object.setAcl(addPublicReadAccess(getDefaultObjectAcl(bucket, listener)));
+                }
+
+                // Give clients an opportunity to decorate the storage
+                // object before we store it.
+                annotateObject(object, listener);
+
+                // Log that we are uploading the file and begin executing the upload.
+                listener.getLogger().println(getModule().prefix(Messages.AbstractUpload_Uploading(relativePath)));
+
+                performUploadWithRetry(executor, service, bucket, object, include);
+                paths.remove(include);
+            }
+
+            @Override
+            public boolean moreWork() {
+                return !paths.isEmpty();
+            }
+        };
+
+        try {
+            RetryStorageOperation.performRequestWithReinitCredentials(a);
+        } catch (ForbiddenException e) {
+            // If the user doesn't own a bucket then they will end up here.
+            throw new UploadException(Messages.AbstractUpload_ForbiddenFileUpload(), e);
+        } catch (ExecutorException e) {
+            throw new UploadException(Messages.AbstractUpload_ExceptionFileUpload(), e);
+        } catch (IOException e) {
+            throw new UploadException(Messages.AbstractUpload_ExceptionFileUpload(), e);
+        } catch (InterruptedException e) {
+            throw new UploadException(Messages.AbstractUpload_ExceptionFileUpload(), e);
+        }
+    }
+
+    /**
+     * Auxiliar method for detecting web-related filename extensions, so setting correctly
+     * Content-Type.
+     */
+    private String detectMIMEType(String filename) {
+        String extension = Files.getFileExtension(filename);
+        if (CONTENT_TYPES.containsKey(extension)) {
+            return CONTENT_TYPES.get(extension);
+        } else {
+            return URLConnection.guessContentTypeFromName(filename);
+        }
+    }
+
+    /**
+     * We need our own storage retry logic because we must recreate the input stream for the media
+     * uploader.
+     */
+    private void performUploadWithRetry(
+            final Executor executor,
+            final Storage service,
+            final Bucket bucket,
+            final StorageObject object,
+            final FilePath include)
+            throws ExecutorException, IOException, InterruptedException {
+        Operation a = new Operation() {
+            public void act() throws IOException, InterruptedException, ExecutorException {
+                // Create the insertion operation with the decorated object and
+                // an input stream of the file contents.
+                try (InputStream is = include.read()) {
+                    Storage.Objects.Insert insertion = service.objects()
+                            .insert(bucket.getName(), object, new InputStreamContent(object.getContentType(), is));
+
+                    // Make the operation non-resumable because we have seen a dramatic
+                    // (e.g. 1000x) speedup from this.
+                    MediaHttpUploader mediaUploader = insertion.getMediaHttpUploader();
+                    if (mediaUploader != null) {
+                        mediaUploader.setDirectUploadEnabled(true);
+                    }
+                    executor.execute(insertion);
+                }
+            }
+        };
+
+        RetryStorageOperation.performRequestWithRetry(executor, a, getModule().getInsertRetryCount());
+    }
+
+    // Fetch the default object ACL for this bucket. Return an empty list if
+    // we cannot.
+    private static List<ObjectAccessControl> getDefaultObjectAcl(Bucket bucket, TaskListener listener) {
+        List<ObjectAccessControl> defaultAcl = bucket.getDefaultObjectAcl();
+        if (defaultAcl == null) {
+            listener.error(Messages.AbstractUpload_BucketObjectAclsError(bucket.getName()));
+            return ImmutableList.of();
+        } else {
+            return defaultAcl;
+        }
+    }
+
+    // Add public access to a given access control list
+    private static List<ObjectAccessControl> addPublicReadAccess(List<ObjectAccessControl> defaultAcl) {
+        List<ObjectAccessControl> acl = Lists.newArrayList(defaultAcl);
+        final String publicEntity = "allUsers";
+        boolean alreadyShared = Iterables.tryFind(acl, new Predicate<ObjectAccessControl>() {
+                    @Override
+                    public boolean apply(ObjectAccessControl access) {
+                        if (access != null) {
+                            return Objects.equal(access.getEntity(), publicEntity);
+                        } else {
+                            throw new NullPointerException(Messages.AbstractUpload_NullAccessError());
+                        }
+                    }
+                })
+                .isPresent();
+        /* If the entity 'allUsers' didn't already has READER or OWNER access, grant
+        READER. This is to avoid having both an OWNER record and a READER record
+        for that same entity */
+        if (!alreadyShared) {
+            acl.add(new ObjectAccessControl().setEntity("allUsers").setRole("READER"));
+        }
+        return acl;
+    }
+
+    /**
+     * Fetches or creates an instance of the bucket with the given name with the specified storage
+     * service.
+     *
+     * @param service Handle to the GCS API.
+     * @param credentials The credentials with which to fetch/create the bucket
+     * @param executor Helper class to make calls to the GCS API.
+     * @param bucketName The top-level bucket name to ensure exists
+     * @return an instance of the named bucket, created or retrieved.
+     * @throws UploadException if any issues are encountered
+     */
+    protected Bucket getOrCreateBucket(
+            Storage service, GoogleRobotCredentials credentials, Executor executor, String bucketName)
+            throws UploadException {
+        try {
+            try {
+                return executor.execute(
+                        service.buckets().get(bucketName).setProjection("full")); // to retrieve the bucket ACLs
+            } catch (NotFoundException e) {
+                try {
+                    // This is roughly the opposite of how the command-line sample does
+                    // things.  We do things this way to optimize for the case where the
+                    // bucket already exists.
+                    Bucket bucket = new Bucket().setName(bucketName);
+                    bucket = executor.execute(service.buckets()
+                            .insert(credentials.getProjectId(), bucket)
+                            .setProjection("full")); // to retrieve the bucket ACLs
+
+                    return bucket;
+                } catch (ConflictException ex) {
+                    // If we get back a "Conflict" response, it means that the bucket
+                    // was inserted between when we first tried to get it and were able
+                    // to successfully insert one.
+                    // NOTE: This could be due to an initial insertion attempt succeeding
+                    // but returning an exception, or a race with another service.
+                    return executor.execute(
+                            service.buckets().get(bucketName).setProjection("full")); // to retrieve the bucket ACLs
+                }
+            }
+        } catch (ExecutorException e) {
+            throw new UploadException(Messages.AbstractUpload_ExceptionGetBucket(bucketName), e);
+        } catch (IOException e) {
+            throw new UploadException(Messages.AbstractUpload_ExceptionGetBucket(bucketName), e);
+        }
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/AbstractUploadDescriptor.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/AbstractUploadDescriptor.java
@@ -27,111 +27,109 @@ import org.kohsuke.stapler.StaplerRequest;
 
 /** Descriptor from which Upload extensions must derive their descriptor. */
 public abstract class AbstractUploadDescriptor extends Descriptor<AbstractUpload> {
-  // The URI "scheme" that prefixes GCS URIs
-  public static final String GCS_SCHEME = "gs://";
-  private final UploadModule module;
+    // The URI "scheme" that prefixes GCS URIs
+    public static final String GCS_SCHEME = "gs://";
+    private final UploadModule module;
 
-  /**
-   * Create the descriptor of the Upload from it's type on associated module for instantiating
-   * dependencies.
-   *
-   * @param clazz Class that extends {@link AbstractUpload}.
-   * @param module Helper class methods to use for execution.
-   */
-  protected AbstractUploadDescriptor(Class<? extends AbstractUpload> clazz, UploadModule module) {
-    super(checkNotNull(clazz));
-    this.module = module;
-  }
-
-  /**
-   * Create the descriptor of the Upload from it's type of {@link AbstractUpload}.
-   *
-   * @param clazz Class that extends {@link AbstractUpload}.
-   */
-  protected AbstractUploadDescriptor(Class<? extends AbstractUpload> clazz) {
-    this(checkNotNull(clazz), new UploadModule());
-  }
-
-  /**
-   * @return Retrieve the module to use for instantiating dependencies for instances described by
-   *     this descriptor.
-   */
-  public synchronized UploadModule getModule() {
-    if (this.module == null) {
-      return new UploadModule();
+    /**
+     * Create the descriptor of the Upload from it's type on associated module for instantiating
+     * dependencies.
+     *
+     * @param clazz Class that extends {@link AbstractUpload}.
+     * @param module Helper class methods to use for execution.
+     */
+    protected AbstractUploadDescriptor(Class<? extends AbstractUpload> clazz, UploadModule module) {
+        super(checkNotNull(clazz));
+        this.module = module;
     }
-    return this.module;
-  }
 
-  /**
-   * This callback validates the {@code bucketNameWithVars} input field's values.
-   *
-   * @param bucketNameWithVars GCS bucket.
-   * @return Valid form validation result or error message if invalid.
-   */
-  public static FormValidation staticDoCheckBucket(final String bucketNameWithVars) {
-    String resolvedInput = Resolve.resolveBuiltin(bucketNameWithVars);
-    if (!resolvedInput.startsWith(GCS_SCHEME)) {
-      return FormValidation.error(
-          Messages.AbstractUploadDescriptor_BadPrefix(resolvedInput, GCS_SCHEME));
+    /**
+     * Create the descriptor of the Upload from it's type of {@link AbstractUpload}.
+     *
+     * @param clazz Class that extends {@link AbstractUpload}.
+     */
+    protected AbstractUploadDescriptor(Class<? extends AbstractUpload> clazz) {
+        this(checkNotNull(clazz), new UploadModule());
     }
-    // Lop off the prefix.
-    resolvedInput = resolvedInput.substring(GCS_SCHEME.length());
 
-    if (resolvedInput.isEmpty()) {
-      return FormValidation.error(Messages.AbstractUploadDescriptor_EmptyBucketName());
+    /**
+     * @return Retrieve the module to use for instantiating dependencies for instances described by
+     *     this descriptor.
+     */
+    public synchronized UploadModule getModule() {
+        if (this.module == null) {
+            return new UploadModule();
+        }
+        return this.module;
     }
-    if (resolvedInput.contains("$")) {
-      // resolved bucket name still contains variable markers
-      return FormValidation.error(
-          Messages.AbstractUploadDescriptor_BadBucketChar(
-              "$", Messages.AbstractUploadDescriptor_DollarSuggest()));
+
+    /**
+     * This callback validates the {@code bucketNameWithVars} input field's values.
+     *
+     * @param bucketNameWithVars GCS bucket.
+     * @return Valid form validation result or error message if invalid.
+     */
+    public static FormValidation staticDoCheckBucket(final String bucketNameWithVars) {
+        String resolvedInput = Resolve.resolveBuiltin(bucketNameWithVars);
+        if (!resolvedInput.startsWith(GCS_SCHEME)) {
+            return FormValidation.error(Messages.AbstractUploadDescriptor_BadPrefix(resolvedInput, GCS_SCHEME));
+        }
+        // Lop off the prefix.
+        resolvedInput = resolvedInput.substring(GCS_SCHEME.length());
+
+        if (resolvedInput.isEmpty()) {
+            return FormValidation.error(Messages.AbstractUploadDescriptor_EmptyBucketName());
+        }
+        if (resolvedInput.contains("$")) {
+            // resolved bucket name still contains variable markers
+            return FormValidation.error(Messages.AbstractUploadDescriptor_BadBucketChar(
+                    "$", Messages.AbstractUploadDescriptor_DollarSuggest()));
+        }
+        // TODO(mattmoor): This has a much more constrained form than the
+        // glob, since it:
+        //  - No wildcards
+        //  - Must be unix
+        //  - Must be relative path
+        // TODO(mattmoor): See if we can get a validity pattern used in the
+        // Cloud Console.
+        // TODO(mattmoor): Check availability or ownership of the bucket
+        return FormValidation.ok();
     }
-    // TODO(mattmoor): This has a much more constrained form than the
-    // glob, since it:
-    //  - No wildcards
-    //  - Must be unix
-    //  - Must be relative path
-    // TODO(mattmoor): See if we can get a validity pattern used in the
-    // Cloud Console.
-    // TODO(mattmoor): Check availability or ownership of the bucket
-    return FormValidation.ok();
-  }
 
-  /**
-   * This callback validates the {@code bucketNameWithVars} input field's values.
-   *
-   * @param bucketNameWithVars GCS bucket.
-   * @return Valid form validation result or error message if invalid.
-   * @throws IOException If there was an issue validating the bucket.
-   */
-  public FormValidation doCheckBucketNameWithVars(@QueryParameter final String bucketNameWithVars)
-      throws IOException {
-    return staticDoCheckBucket(bucketNameWithVars);
-  }
-
-  /**
-   * Form validation for bucket parameter.
-   *
-   * @param bucket GCS bucket.
-   * @return Valid form validation result or error message if invalid.
-   * @throws IOException If there was an issue validating the bucket.
-   */
-  public FormValidation doCheckBucket(@QueryParameter final String bucket) throws IOException {
-    return staticDoCheckBucket(bucket);
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public AbstractUpload newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-    // Since the config form lists the optional parameter pathPrefix as inline,
-    // it will be passed through even if stripPathPrefix is false. This might
-    // cause problems if the user, for example, fills in the field and then
-    // unchecks the checkbox. So, explicitly remove pathPrefix whenever
-    // stripPathPrefix is false.
-    if (Boolean.FALSE.equals(formData.remove("stripPathPrefix"))) {
-      formData.remove("pathPrefix");
+    /**
+     * This callback validates the {@code bucketNameWithVars} input field's values.
+     *
+     * @param bucketNameWithVars GCS bucket.
+     * @return Valid form validation result or error message if invalid.
+     * @throws IOException If there was an issue validating the bucket.
+     */
+    public FormValidation doCheckBucketNameWithVars(@QueryParameter final String bucketNameWithVars)
+            throws IOException {
+        return staticDoCheckBucket(bucketNameWithVars);
     }
-    return super.newInstance(req, formData);
-  }
+
+    /**
+     * Form validation for bucket parameter.
+     *
+     * @param bucket GCS bucket.
+     * @return Valid form validation result or error message if invalid.
+     * @throws IOException If there was an issue validating the bucket.
+     */
+    public FormValidation doCheckBucket(@QueryParameter final String bucket) throws IOException {
+        return staticDoCheckBucket(bucket);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public AbstractUpload newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+        // Since the config form lists the optional parameter pathPrefix as inline,
+        // it will be passed through even if stripPathPrefix is false. This might
+        // cause problems if the user, for example, fills in the field and then
+        // unchecks the checkbox. So, explicitly remove pathPrefix whenever
+        // stripPathPrefix is false.
+        if (Boolean.FALSE.equals(formData.remove("stripPathPrefix"))) {
+            formData.remove("pathPrefix");
+        }
+        return super.newInstance(req, formData);
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/ClassicUploadStep.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/ClassicUploadStep.java
@@ -43,204 +43,203 @@ import org.kohsuke.stapler.StaplerRequest;
  */
 @RequiresDomain(StorageScopeRequirement.class)
 public class ClassicUploadStep extends Builder implements SimpleBuildStep, Serializable {
-  private ClassicUpload upload;
-  private final String credentialsId;
+    private ClassicUpload upload;
+    private final String credentialsId;
 
-  /**
-   * DataBoundConstructor for the classic upload step.
-   *
-   * @see ClassicUpload#ClassicUpload
-   * @param credentialsId The unique ID for the credentials we are using to authenticate with GCS.
-   * @param bucket GCS bucket to upload build artifacts to.
-   * @param pattern The glob of files to upload, which potentially contains unresolved symbols, such
-   *     as $JOB_NAME and $BUILD_NUMBER.
-   */
-  @DataBoundConstructor
-  public ClassicUploadStep(String credentialsId, String bucket, String pattern) {
-    this(credentialsId, bucket, null, pattern);
-  }
-
-  /**
-   * Construct the classic upload step.
-   *
-   * @see ClassicUpload#ClassicUpload
-   * @param credentialsId The unique ID for the credentials we are using to authenticate with GCS.
-   * @param bucket GCS bucket to upload build artifacts to.
-   * @param module Helper class for connecting to the GCS API.
-   * @param pattern The glob of files to upload, which potentially contains unresolved symbols, such
-   *     as $JOB_NAME and $BUILD_NUMBER.
-   */
-  public ClassicUploadStep(
-      String credentialsId, String bucket, @Nullable UploadModule module, String pattern) {
-    this.credentialsId = credentialsId;
-    upload = new ClassicUpload(bucket, module, pattern, null, null);
-
-    // Build steps will not be executed following a failed build.
-    // Pipeline steps performed sequentually will not be executed
-    //   following a failed step
-    // If we ever get to execute this on a failed build, that must
-    // have been done intentionally, e.g., using "post" with appropriate
-    // flags. This should be allowed.
-    upload.setForFailedJobs(true);
-  }
-
-  /**
-   * @param sharedPublicly Whether to surface the file being uploaded to anyone with the link.
-   */
-  @DataBoundSetter
-  public void setSharedPublicly(boolean sharedPublicly) {
-    upload.setSharedPublicly(sharedPublicly);
-  }
-
-  /**
-   * @return Whether to surface the file being uploaded to anyone with the link.
-   */
-  public boolean isSharedPublicly() {
-    return upload.isSharedPublicly();
-  }
-
-  /**
-   * @param showInline Whether to indicate in metadata that the file should be viewable inline in
-   *     web browsers, rather than requiring it to be downloaded first.
-   */
-  @DataBoundSetter
-  public void setShowInline(boolean showInline) {
-    upload.setShowInline(showInline);
-  }
-
-  /**
-   * @return Whether to indicate in metadata that the file should be viewable inline in web
-   *     browsers, rather than requiring it to be downloaded first.
-   */
-  public boolean isShowInline() {
-    return upload.isShowInline();
-  }
-
-  /**
-   * @param pathPrefix The path prefix that will be stripped from uploaded files. May be null if no
-   *     path prefix needs to be stripped.
-   *     <p>Filenames that do not start with this prefix will not be modified. Trailing slash is
-   *     automatically added if it is missing.
-   */
-  @DataBoundSetter
-  public void setPathPrefix(@Nullable String pathPrefix) {
-    upload.setPathPrefix(pathPrefix);
-  }
-
-  /**
-   * @return pathPrefix The path prefix that will be stripped from uploaded files. May be null if no
-   *     path prefix needs to be stripped.
-   *     <p>Filenames that do not start with this prefix will not be modified. Trailing slash is
-   *     automatically added if it is missing.
-   */
-  @Nullable
-  public String getPathPrefix() {
-    return upload.getPathPrefix();
-  }
-
-  /**
-   * @return The glob of files to upload, which potentially contains unresolved symbols, such as
-   *     $JOB_NAME and $BUILD_NUMBER.
-   */
-  public String getPattern() {
-    return upload.getPattern();
-  }
-
-  /**
-   * @return The bucket name specified by the user, which potentially contains unresolved symbols,
-   *     such as $JOB_NAME and $BUILD_NUMBER.
-   */
-  public String getBucket() {
-    return upload.getBucket();
-  }
-
-  /**
-   * @return The unique ID for the credentials we are using to authenticate with GCS.
-   */
-  public String getCredentialsId() {
-    return credentialsId;
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public BuildStepMonitor getRequiredMonitorService() {
-    return BuildStepMonitor.NONE;
-  }
-
-  /**
-   * The main entry point of this extension. Uploads files that match an Ant-style glob, e.g. ** /
-   * *.java relative to the build workspace to a GCS bucket.
-   *
-   * @param run Current job being run.
-   * @param workspace Workspace of node running the job.
-   * @param launcher {@link Launcher} for this job.
-   * @param listener Listener for events of this job.
-   * @throws IOException If there was an issue performing the upload.
-   */
-  @Override
-  public void perform(Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener listener)
-      throws IOException {
-    // setForFailedJobs was set to true in the constructor. However,
-    // some jobs might have been created before that bug fix.
-    // For those, set this here as well.
-    upload.setForFailedJobs(true);
-
-    try {
-      upload.perform(getCredentialsId(), run, workspace, listener);
-    } catch (UploadException e) {
-      throw new IOException("Could not perform upload", e);
-    }
-  }
-
-  /** Descriptor for the class. */
-  @Extension
-  @Symbol("googleStorageUpload")
-  public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
-
-    /** {@inheritDoc} */
-    @Override
-    public String getDisplayName() {
-      return Messages.ClassicUpload_BuildStepDisplayName();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean isApplicable(Class<? extends AbstractProject> jobType) {
-      return true;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public Builder newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-      // Since the config form lists the optional parameter pathPrefix as
-      // inline, it will be passed through even if stripPathPrefix is false.
-      // This might cause problems if the user, for example, fills in the field
-      // and then unchecks the checkbox. So, explicitly remove pathPrefix
-      // whenever stripPathPrefix is false.
-      if (Boolean.FALSE.equals(formData.remove("stripPathPrefix"))) {
-        formData.remove("pathPrefix");
-      }
-      return super.newInstance(req, formData);
+    /**
+     * DataBoundConstructor for the classic upload step.
+     *
+     * @see ClassicUpload#ClassicUpload
+     * @param credentialsId The unique ID for the credentials we are using to authenticate with GCS.
+     * @param bucket GCS bucket to upload build artifacts to.
+     * @param pattern The glob of files to upload, which potentially contains unresolved symbols, such
+     *     as $JOB_NAME and $BUILD_NUMBER.
+     */
+    @DataBoundConstructor
+    public ClassicUploadStep(String credentialsId, String bucket, String pattern) {
+        this(credentialsId, bucket, null, pattern);
     }
 
     /**
-     * This callback validates the {@code bucket} input field's values.
+     * Construct the classic upload step.
      *
-     * @param bucket GCS bucket to upload files to.
-     * @return Valid form validation result or error message if invalid.
+     * @see ClassicUpload#ClassicUpload
+     * @param credentialsId The unique ID for the credentials we are using to authenticate with GCS.
+     * @param bucket GCS bucket to upload build artifacts to.
+     * @param module Helper class for connecting to the GCS API.
+     * @param pattern The glob of files to upload, which potentially contains unresolved symbols, such
+     *     as $JOB_NAME and $BUILD_NUMBER.
      */
-    public FormValidation doCheckBucket(@QueryParameter final String bucket) {
-      return ClassicUpload.DescriptorImpl.staticDoCheckBucket(bucket);
+    public ClassicUploadStep(String credentialsId, String bucket, @Nullable UploadModule module, String pattern) {
+        this.credentialsId = credentialsId;
+        upload = new ClassicUpload(bucket, module, pattern, null, null);
+
+        // Build steps will not be executed following a failed build.
+        // Pipeline steps performed sequentually will not be executed
+        //   following a failed step
+        // If we ever get to execute this on a failed build, that must
+        // have been done intentionally, e.g., using "post" with appropriate
+        // flags. This should be allowed.
+        upload.setForFailedJobs(true);
     }
 
     /**
-     * This callback validates the {@code pattern} input field's values.
-     *
-     * @param pattern GCS bucket to upload files to.
-     * @return Valid form validation result or error message if invalid.
+     * @param sharedPublicly Whether to surface the file being uploaded to anyone with the link.
      */
-    public static FormValidation doCheckPattern(@QueryParameter final String pattern) {
-      return ClassicUpload.DescriptorImpl.staticDoCheckPattern(pattern);
+    @DataBoundSetter
+    public void setSharedPublicly(boolean sharedPublicly) {
+        upload.setSharedPublicly(sharedPublicly);
     }
-  }
+
+    /**
+     * @return Whether to surface the file being uploaded to anyone with the link.
+     */
+    public boolean isSharedPublicly() {
+        return upload.isSharedPublicly();
+    }
+
+    /**
+     * @param showInline Whether to indicate in metadata that the file should be viewable inline in
+     *     web browsers, rather than requiring it to be downloaded first.
+     */
+    @DataBoundSetter
+    public void setShowInline(boolean showInline) {
+        upload.setShowInline(showInline);
+    }
+
+    /**
+     * @return Whether to indicate in metadata that the file should be viewable inline in web
+     *     browsers, rather than requiring it to be downloaded first.
+     */
+    public boolean isShowInline() {
+        return upload.isShowInline();
+    }
+
+    /**
+     * @param pathPrefix The path prefix that will be stripped from uploaded files. May be null if no
+     *     path prefix needs to be stripped.
+     *     <p>Filenames that do not start with this prefix will not be modified. Trailing slash is
+     *     automatically added if it is missing.
+     */
+    @DataBoundSetter
+    public void setPathPrefix(@Nullable String pathPrefix) {
+        upload.setPathPrefix(pathPrefix);
+    }
+
+    /**
+     * @return pathPrefix The path prefix that will be stripped from uploaded files. May be null if no
+     *     path prefix needs to be stripped.
+     *     <p>Filenames that do not start with this prefix will not be modified. Trailing slash is
+     *     automatically added if it is missing.
+     */
+    @Nullable
+    public String getPathPrefix() {
+        return upload.getPathPrefix();
+    }
+
+    /**
+     * @return The glob of files to upload, which potentially contains unresolved symbols, such as
+     *     $JOB_NAME and $BUILD_NUMBER.
+     */
+    public String getPattern() {
+        return upload.getPattern();
+    }
+
+    /**
+     * @return The bucket name specified by the user, which potentially contains unresolved symbols,
+     *     such as $JOB_NAME and $BUILD_NUMBER.
+     */
+    public String getBucket() {
+        return upload.getBucket();
+    }
+
+    /**
+     * @return The unique ID for the credentials we are using to authenticate with GCS.
+     */
+    public String getCredentialsId() {
+        return credentialsId;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public BuildStepMonitor getRequiredMonitorService() {
+        return BuildStepMonitor.NONE;
+    }
+
+    /**
+     * The main entry point of this extension. Uploads files that match an Ant-style glob, e.g. ** /
+     * *.java relative to the build workspace to a GCS bucket.
+     *
+     * @param run Current job being run.
+     * @param workspace Workspace of node running the job.
+     * @param launcher {@link Launcher} for this job.
+     * @param listener Listener for events of this job.
+     * @throws IOException If there was an issue performing the upload.
+     */
+    @Override
+    public void perform(Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener listener)
+            throws IOException {
+        // setForFailedJobs was set to true in the constructor. However,
+        // some jobs might have been created before that bug fix.
+        // For those, set this here as well.
+        upload.setForFailedJobs(true);
+
+        try {
+            upload.perform(getCredentialsId(), run, workspace, listener);
+        } catch (UploadException e) {
+            throw new IOException("Could not perform upload", e);
+        }
+    }
+
+    /** Descriptor for the class. */
+    @Extension
+    @Symbol("googleStorageUpload")
+    public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
+
+        /** {@inheritDoc} */
+        @Override
+        public String getDisplayName() {
+            return Messages.ClassicUpload_BuildStepDisplayName();
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+            return true;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public Builder newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+            // Since the config form lists the optional parameter pathPrefix as
+            // inline, it will be passed through even if stripPathPrefix is false.
+            // This might cause problems if the user, for example, fills in the field
+            // and then unchecks the checkbox. So, explicitly remove pathPrefix
+            // whenever stripPathPrefix is false.
+            if (Boolean.FALSE.equals(formData.remove("stripPathPrefix"))) {
+                formData.remove("pathPrefix");
+            }
+            return super.newInstance(req, formData);
+        }
+
+        /**
+         * This callback validates the {@code bucket} input field's values.
+         *
+         * @param bucket GCS bucket to upload files to.
+         * @return Valid form validation result or error message if invalid.
+         */
+        public FormValidation doCheckBucket(@QueryParameter final String bucket) {
+            return ClassicUpload.DescriptorImpl.staticDoCheckBucket(bucket);
+        }
+
+        /**
+         * This callback validates the {@code pattern} input field's values.
+         *
+         * @param pattern GCS bucket to upload files to.
+         * @return Valid form validation result or error message if invalid.
+         */
+        public static FormValidation doCheckPattern(@QueryParameter final String pattern) {
+            return ClassicUpload.DescriptorImpl.staticDoCheckPattern(pattern);
+        }
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/DownloadStep.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/DownloadStep.java
@@ -66,454 +66,438 @@ import org.kohsuke.stapler.StaplerRequest;
 /** A step to allow Download from Google Cloud Storage as a Build step and in pipeline. */
 @RequiresDomain(value = StorageScopeRequirement.class)
 public class DownloadStep extends Builder implements SimpleBuildStep, Serializable {
-  private static final long serialVersionUID = 1;
-  private static final Logger logger = Logger.getLogger(DownloadStep.class.getName());
-  private final String credentialsId;
-  private final String bucketUri;
-  private final String localDirectory;
-  private String pathPrefix;
-  /** The module to use for providing dependencies. */
-  private final transient UploadModule module;
-
-  /**
-   * DataBoundConstructor for DownloadStep.
-   *
-   * @param credentialsId The unique ID for the credentials we are using to authenticate with GCS.
-   * @param bucketUri Name of the GCS bucket. e.g. gs://MY_BUCKET_NAME
-   * @param localDirectory Path of the local directory in Jenkins to download the file to.
-   */
-  @DataBoundConstructor
-  public DownloadStep(String credentialsId, String bucketUri, String localDirectory) {
-    this(credentialsId, bucketUri, localDirectory, null);
-  }
-
-  /**
-   * Constructor for DownloadStep.
-   *
-   * @param credentialsId The unique ID for the credentials we are using to authenticate with GCS.
-   * @param bucketUri Name of the GCS bucket. e.g. gs://MY_BUCKET_NAME
-   * @param localDirectory Path of the local directory in Jenkins to download the file to.
-   * @param module An {@link UploadModule} to use for execution.
-   */
-  public DownloadStep(
-      String credentialsId,
-      String bucketUri,
-      String localDirectory,
-      @Nullable UploadModule module) {
-    if (module != null) {
-      this.module = module;
-    } else {
-      this.module = new UploadModule();
-    }
-
-    this.bucketUri = bucketUri;
-    this.credentialsId = credentialsId;
-    this.localDirectory = localDirectory;
-  }
-
-  /**
-   * @return The bucket uri specified by the user, which potentially contains unresolved symbols,
-   *     such as $JOB_NAME and $BUILD_NUMBER.
-   */
-  public String getBucketUri() {
-    return bucketUri;
-  }
-
-  /**
-   * @return The local directory in the Jenkins workspace that will receive the files. This might
-   *     contain unresolved symbols, such as $JOB_NAME and $BUILD_NUMBER.
-   */
-  public String getLocalDirectory() {
-    return localDirectory;
-  }
-
-  /**
-   * @param pathPrefix The path prefix that will be stripped from downloaded files. May be null if
-   *     no path prefix needs to be stripped.
-   *     <p>Filenames that do not start with this prefix will not be modified. Trailing slash is
-   *     automatically added if it is missing.
-   */
-  @DataBoundSetter
-  public void setPathPrefix(@Nullable String pathPrefix) {
-    if (pathPrefix != null && !pathPrefix.endsWith("/")) {
-      pathPrefix += "/";
-    }
-    this.pathPrefix = pathPrefix;
-  }
-
-  /**
-   * @return The path prefix that will be stripped from downloaded files. May be null if no path
-   *     prefix needs to be stripped.
-   *     <p>Filenames that do not start with this prefix will not be modified. Trailing slash is
-   *     automatically added if it is missing.
-   */
-  @Nullable
-  public String getPathPrefix() {
-    return pathPrefix;
-  }
-
-  /**
-   * @return The UploadModule used for providing dependencies.
-   */
-  protected synchronized UploadModule getModule() {
-    if (this.module == null) {
-      return new UploadModule();
-    }
-    return this.module;
-  }
-
-  /**
-   * @return The unique ID for the credentials we are using to authenticate with GCS.
-   */
-  public String getCredentialsId() {
-    return credentialsId;
-  }
-
-  /**
-   * @return The credentials we are using to authenticate with GCS.
-   */
-  public GoogleRobotCredentials getCredentials() {
-    return GoogleRobotCredentials.getById(getCredentialsId());
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public BuildStepMonitor getRequiredMonitorService() {
-    return BuildStepMonitor.NONE;
-  }
-
-  /**
-   * The main entry point of this extension. Downloads the resolved GCS objects from the resolved
-   * GCS bucket to a local directory.
-   *
-   * @param run Current job being run.
-   * @param workspace Workspace of node running the job.
-   * @param launcher {@link Launcher} for this job.
-   * @param listener Listener for events of this job.
-   * @throws IOException If there was an issue parsing the bucket URI.
-   * @throws InterruptedException If there was an issue initiating downloads at workspace or
-   *     expanding variables in the pathPrefix.
-   */
-  @Override
-  public void perform(
-      @NonNull Run<?, ?> run,
-      @NonNull FilePath workspace,
-      @NonNull Launcher launcher,
-      @NonNull TaskListener listener)
-      throws IOException, InterruptedException {
-    try {
-      String version = getModule().getVersion();
-      String path = StorageUtil.replaceMacro(getBucketUri(), run, listener);
-      BucketPath bucketPath = new BucketPath(path);
-      if (bucketPath.error()) {
-        throw new IOException("Invalid bucket path: " + getBucketUri());
-      }
-
-      String dirName = StorageUtil.replaceMacro(getLocalDirectory(), run, listener);
-      FilePath dirPath = workspace.child(dirName);
-
-      List<StorageObjectId> objects = resolveBucketPath(bucketPath, getCredentials(), version);
-
-      listener
-          .getLogger()
-          .println(getModule().prefix(Messages.Download_FoundForPattern(objects.size(), path)));
-
-      // TODO(agoulti): add a download report.
-
-      String resolvedPrefix = StorageUtil.replaceMacro(pathPrefix, run, listener);
-
-      initiateDownloadsAtWorkspace(
-          getCredentials(), objects, dirPath, listener, version, resolvedPrefix);
-    } catch (ExecutorException e) {
-      throw new IOException(Messages.Download_DownloadException(), e);
-    }
-  }
-
-  private void performDownloadWithRetry(
-      final Executor executor,
-      final Storage service,
-      final StorageObjectId obj,
-      final FilePath localName,
-      final UploadModule module,
-      final TaskListener listener)
-      throws IOException, InterruptedException, ExecutorException {
-    Operation a =
-        new Operation() {
-          public void act() throws IOException, InterruptedException, ExecutorException {
-            listener
-                .getLogger()
-                .println(module.prefix(Messages.Download_Downloading(obj.getName(), localName)));
-            Storage.Objects.Get getObject = service.objects().get(obj.getBucket(), obj.getName());
-            MediaHttpDownloader downloader = getObject.getMediaHttpDownloader();
-            if (downloader != null) {
-              downloader.setDirectDownloadEnabled(true);
-            }
-
-            InputStream is = module.executeMediaAsInputStream(getObject);
-            localName.copyFrom(is);
-          }
-        };
-
-    RetryStorageOperation.performRequestWithRetry(executor, a, module.getInsertRetryCount());
-  }
-
-  private void performDownloads(
-      final GoogleRobotCredentials credentials,
-      final FilePath localDir,
-      final List<StorageObjectId> objs,
-      final TaskListener listener,
-      final String version,
-      final String resolvedPrefix)
-      throws IOException {
-    RepeatOperation<IOException> a =
-        new RepeatOperation<IOException>() {
-          private Queue<StorageObjectId> objects = new LinkedList<StorageObjectId>(objs);
-          Executor executor = getModule().newExecutor();
-
-          Storage service;
-
-          public void initCredentials() throws IOException {
-            service = getModule().getStorageService(credentials, version);
-          }
-
-          public boolean moreWork() {
-            return !objects.isEmpty();
-          }
-
-          public void act() throws IOException, InterruptedException, ExecutorException {
-            StorageObjectId obj = objects.peek();
-
-            String addPath = StorageUtil.getStrippedFilename(obj.getName(), resolvedPrefix);
-            FilePath localName = localDir.withSuffix("/" + addPath);
-
-            performDownloadWithRetry(executor, service, obj, localName, getModule(), listener);
-            objects.remove();
-          }
-        };
-
-    try {
-      RetryStorageOperation.performRequestWithReinitCredentials(a);
-    } catch (ExecutorException e) {
-      throw new IOException(Messages.Download_DownloadException(), e);
-    } catch (InterruptedException e) {
-      throw new IOException(Messages.Download_DownloadException(), e);
-    }
-  }
-
-  private void initiateDownloadsAtWorkspace(
-      final GoogleRobotCredentials credentials,
-      final List<StorageObjectId> objects,
-      final FilePath localDir,
-      final TaskListener listener,
-      final String version,
-      final String resolvedPrefix)
-      throws IOException, InterruptedException {
-    try {
-      // Use remotable credential to access the storage service from the
-      // remote machine.
-      final GoogleRobotCredentials remoteCredentials =
-          checkNotNull(credentials).forRemote(getModule().getRequirement());
-
-      localDir.act(
-          new MasterToSlaveCallable<Void, IOException>() {
-            @Override
-            public Void call() throws IOException {
-              performDownloads(
-                  remoteCredentials, localDir, objects, listener, version, resolvedPrefix);
-              return (Void) null;
-            }
-          });
-    } catch (GeneralSecurityException e) {
-      throw new IOException(Messages.AbstractUpload_RemoteCredentialError(), e);
-    }
-  }
-
-  /** A class to store StorageObject information in a serializable manner. */
-  protected static class StorageObjectId implements Serializable {
-    public StorageObjectId(StorageObject obj) {
-      this.bucket = obj.getBucket();
-      this.name = obj.getName();
-    }
-
-    public String getBucket() {
-      return bucket;
-    }
-
-    public String getName() {
-      return name;
-    }
-
-    private final String bucket;
-    private final String name;
-  }
-
-  /**
-   * Split the string on wildcards ("*").
-   *
-   * <p>String.split removes trailing empty strings, for example, "a", "a*" and "a**" and would
-   * produce the same result, so that method is not suitable.
-   *
-   * @param uri URI supplied to be split.
-   * @return URI split by "*" wildcard.
-   * @throws AbortException If there is more than one wild card character in the provided string.
-   */
-  public static String[] split(String uri) throws AbortException {
-    int occurs = StringUtils.countMatches(uri, "*");
-
-    if (occurs == 0) {
-      return new String[] {uri};
-    }
-
-    if (occurs > 1) {
-      throw new AbortException(Messages.Download_UnsupportedMultipleAsterisks(uri));
-    }
-
-    int index = uri.indexOf('*');
-    return new String[] {uri.substring(0, index), uri.substring(index + 1)};
-  }
-
-  /** Verifies that the given path is supported within current limitations */
-  private static void verifySupported(BucketPath path) throws AbortException {
-    if (path.getBucket().contains("*")) {
-      throw new AbortException(Messages.Download_UnsupportedAsteriskInBucket(path.getBucket()));
-    }
-    String[] pieces = split(path.getObject());
-    if (pieces.length == 2) {
-      if (pieces[1].contains("/")) {
-        throw new AbortException(Messages.Download_UnsupportedDirSuffix(path.getObject()));
-      }
-    }
-  }
-
-  /**
-   * Take the bucket path and return a list of objects in the cloud that match it.
-   *
-   * <p>This will eventually handle wildcards, but for now is limited to directly specifying the
-   * object.
-   */
-  private List<StorageObjectId> resolveBucketPath(
-      BucketPath bucketPath, GoogleRobotCredentials credentials, String version)
-      throws IOException, ExecutorException {
-    Storage service = getModule().getStorageService(credentials, version);
-    Executor executor = getModule().newExecutor();
-
-    List<StorageObjectId> result = new ArrayList<StorageObjectId>();
-
-    verifySupported(bucketPath);
-
-    // Allow a single asterisk in the object name for now.
-    // Let the behavior be consistent with
-    // https://cloud.google.com/storage/docs/gsutil/addlhelp/WildcardNames
-    //
-    // Support for richer constructs will be added as needed.
-
-    String[] pieces = split(bucketPath.getObject());
-
-    if (pieces.length == 1) {
-      // No wildcards. Do simple lookup
-      Storage.Objects.Get obj =
-          service.objects().get(bucketPath.getBucket(), bucketPath.getObject());
-
-      result.add(new StorageObjectId(executor.execute(obj)));
-
-      return result;
-    }
-
-    // Single wildcard, of the form pre/fix/log_*_some.txt
-
-    String bucketPathPrefix = pieces[0];
-    String bucketPathSuffix = pieces[1];
-
-    String pageToken = "";
-    do {
-      Storage.Objects.List list =
-          service
-              .objects()
-              .list(bucketPath.getBucket())
-              .setPrefix(bucketPathPrefix)
-              .setDelimiter("/");
-      if (pageToken.length() > 0) {
-        list.setPageToken(pageToken);
-      }
-
-      Objects objects = executor.execute(list);
-      pageToken = objects.getNextPageToken();
-
-      // Collect the items that match the suffix
-      for (StorageObject o : objects.getItems()) {
-        if (o.getName().endsWith(bucketPathSuffix)) {
-          result.add(new StorageObjectId(o));
-        }
-      }
-    } while (pageToken != null && pageToken.length() > 0);
-
-    return result;
-  }
-
-  /** {@inheritDoc} */
-  public DescriptorImpl getDescriptor() {
-    return (DescriptorImpl) checkNotNull(Jenkins.get()).getDescriptor(getClass());
-  }
-
-  /** Descriptor for the DownloadStep */
-  @Extension
-  @Symbol("googleStorageDownload")
-  public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
-    private UploadModule module;
+    private static final long serialVersionUID = 1;
+    private static final Logger logger = Logger.getLogger(DownloadStep.class.getName());
+    private final String credentialsId;
+    private final String bucketUri;
+    private final String localDirectory;
+    private String pathPrefix;
+    /** The module to use for providing dependencies. */
+    private final transient UploadModule module;
 
     /**
-     * @return Module for the DescriptorImpl.
-     */
-    public synchronized UploadModule getModule() {
-      if (this.module == null) {
-        return new UploadModule();
-      }
-      return this.module;
-    }
-
-    /** Constructor for {@link DownloadStep}'s DescriptorImpl. */
-    public DescriptorImpl() {
-      this.module = new UploadModule();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public String getDisplayName() {
-      return Messages.Download_BuildStepDisplayName();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean isApplicable(Class<? extends AbstractProject> jobType) {
-      return true;
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public Builder newInstance(StaplerRequest req, JSONObject formData) throws FormException {
-      if (Boolean.FALSE.equals(formData.remove("stripPathPrefix"))) {
-        formData.remove("pathPrefix");
-      }
-      return super.newInstance(req, formData);
-    }
-
-    /**
-     * This callback validates the {@code bucketNameWithVars} input field's values.
+     * DataBoundConstructor for DownloadStep.
      *
+     * @param credentialsId The unique ID for the credentials we are using to authenticate with GCS.
      * @param bucketUri Name of the GCS bucket. e.g. gs://MY_BUCKET_NAME
-     * @return Valid form validation result or error message if invalid.
+     * @param localDirectory Path of the local directory in Jenkins to download the file to.
      */
-    public FormValidation doCheckBucketUri(@QueryParameter final String bucketUri) {
-      try {
-        BucketPath path = new BucketPath(bucketUri);
-        verifySupported(path);
-      } catch (AbortException e) {
-        return FormValidation.error(e.getMessage());
-      } catch (IllegalArgumentException e) {
-        return FormValidation.error(e.getMessage());
-      }
-
-      return ClassicUpload.DescriptorImpl.staticDoCheckBucket(bucketUri);
+    @DataBoundConstructor
+    public DownloadStep(String credentialsId, String bucketUri, String localDirectory) {
+        this(credentialsId, bucketUri, localDirectory, null);
     }
-  }
+
+    /**
+     * Constructor for DownloadStep.
+     *
+     * @param credentialsId The unique ID for the credentials we are using to authenticate with GCS.
+     * @param bucketUri Name of the GCS bucket. e.g. gs://MY_BUCKET_NAME
+     * @param localDirectory Path of the local directory in Jenkins to download the file to.
+     * @param module An {@link UploadModule} to use for execution.
+     */
+    public DownloadStep(String credentialsId, String bucketUri, String localDirectory, @Nullable UploadModule module) {
+        if (module != null) {
+            this.module = module;
+        } else {
+            this.module = new UploadModule();
+        }
+
+        this.bucketUri = bucketUri;
+        this.credentialsId = credentialsId;
+        this.localDirectory = localDirectory;
+    }
+
+    /**
+     * @return The bucket uri specified by the user, which potentially contains unresolved symbols,
+     *     such as $JOB_NAME and $BUILD_NUMBER.
+     */
+    public String getBucketUri() {
+        return bucketUri;
+    }
+
+    /**
+     * @return The local directory in the Jenkins workspace that will receive the files. This might
+     *     contain unresolved symbols, such as $JOB_NAME and $BUILD_NUMBER.
+     */
+    public String getLocalDirectory() {
+        return localDirectory;
+    }
+
+    /**
+     * @param pathPrefix The path prefix that will be stripped from downloaded files. May be null if
+     *     no path prefix needs to be stripped.
+     *     <p>Filenames that do not start with this prefix will not be modified. Trailing slash is
+     *     automatically added if it is missing.
+     */
+    @DataBoundSetter
+    public void setPathPrefix(@Nullable String pathPrefix) {
+        if (pathPrefix != null && !pathPrefix.endsWith("/")) {
+            pathPrefix += "/";
+        }
+        this.pathPrefix = pathPrefix;
+    }
+
+    /**
+     * @return The path prefix that will be stripped from downloaded files. May be null if no path
+     *     prefix needs to be stripped.
+     *     <p>Filenames that do not start with this prefix will not be modified. Trailing slash is
+     *     automatically added if it is missing.
+     */
+    @Nullable
+    public String getPathPrefix() {
+        return pathPrefix;
+    }
+
+    /**
+     * @return The UploadModule used for providing dependencies.
+     */
+    protected synchronized UploadModule getModule() {
+        if (this.module == null) {
+            return new UploadModule();
+        }
+        return this.module;
+    }
+
+    /**
+     * @return The unique ID for the credentials we are using to authenticate with GCS.
+     */
+    public String getCredentialsId() {
+        return credentialsId;
+    }
+
+    /**
+     * @return The credentials we are using to authenticate with GCS.
+     */
+    public GoogleRobotCredentials getCredentials() {
+        return GoogleRobotCredentials.getById(getCredentialsId());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public BuildStepMonitor getRequiredMonitorService() {
+        return BuildStepMonitor.NONE;
+    }
+
+    /**
+     * The main entry point of this extension. Downloads the resolved GCS objects from the resolved
+     * GCS bucket to a local directory.
+     *
+     * @param run Current job being run.
+     * @param workspace Workspace of node running the job.
+     * @param launcher {@link Launcher} for this job.
+     * @param listener Listener for events of this job.
+     * @throws IOException If there was an issue parsing the bucket URI.
+     * @throws InterruptedException If there was an issue initiating downloads at workspace or
+     *     expanding variables in the pathPrefix.
+     */
+    @Override
+    public void perform(
+            @NonNull Run<?, ?> run,
+            @NonNull FilePath workspace,
+            @NonNull Launcher launcher,
+            @NonNull TaskListener listener)
+            throws IOException, InterruptedException {
+        try {
+            String version = getModule().getVersion();
+            String path = StorageUtil.replaceMacro(getBucketUri(), run, listener);
+            BucketPath bucketPath = new BucketPath(path);
+            if (bucketPath.error()) {
+                throw new IOException("Invalid bucket path: " + getBucketUri());
+            }
+
+            String dirName = StorageUtil.replaceMacro(getLocalDirectory(), run, listener);
+            FilePath dirPath = workspace.child(dirName);
+
+            List<StorageObjectId> objects = resolveBucketPath(bucketPath, getCredentials(), version);
+
+            listener.getLogger().println(getModule().prefix(Messages.Download_FoundForPattern(objects.size(), path)));
+
+            // TODO(agoulti): add a download report.
+
+            String resolvedPrefix = StorageUtil.replaceMacro(pathPrefix, run, listener);
+
+            initiateDownloadsAtWorkspace(getCredentials(), objects, dirPath, listener, version, resolvedPrefix);
+        } catch (ExecutorException e) {
+            throw new IOException(Messages.Download_DownloadException(), e);
+        }
+    }
+
+    private void performDownloadWithRetry(
+            final Executor executor,
+            final Storage service,
+            final StorageObjectId obj,
+            final FilePath localName,
+            final UploadModule module,
+            final TaskListener listener)
+            throws IOException, InterruptedException, ExecutorException {
+        Operation a = new Operation() {
+            public void act() throws IOException, InterruptedException, ExecutorException {
+                listener.getLogger().println(module.prefix(Messages.Download_Downloading(obj.getName(), localName)));
+                Storage.Objects.Get getObject = service.objects().get(obj.getBucket(), obj.getName());
+                MediaHttpDownloader downloader = getObject.getMediaHttpDownloader();
+                if (downloader != null) {
+                    downloader.setDirectDownloadEnabled(true);
+                }
+
+                InputStream is = module.executeMediaAsInputStream(getObject);
+                localName.copyFrom(is);
+            }
+        };
+
+        RetryStorageOperation.performRequestWithRetry(executor, a, module.getInsertRetryCount());
+    }
+
+    private void performDownloads(
+            final GoogleRobotCredentials credentials,
+            final FilePath localDir,
+            final List<StorageObjectId> objs,
+            final TaskListener listener,
+            final String version,
+            final String resolvedPrefix)
+            throws IOException {
+        RepeatOperation<IOException> a = new RepeatOperation<IOException>() {
+            private Queue<StorageObjectId> objects = new LinkedList<StorageObjectId>(objs);
+            Executor executor = getModule().newExecutor();
+
+            Storage service;
+
+            public void initCredentials() throws IOException {
+                service = getModule().getStorageService(credentials, version);
+            }
+
+            public boolean moreWork() {
+                return !objects.isEmpty();
+            }
+
+            public void act() throws IOException, InterruptedException, ExecutorException {
+                StorageObjectId obj = objects.peek();
+
+                String addPath = StorageUtil.getStrippedFilename(obj.getName(), resolvedPrefix);
+                FilePath localName = localDir.withSuffix("/" + addPath);
+
+                performDownloadWithRetry(executor, service, obj, localName, getModule(), listener);
+                objects.remove();
+            }
+        };
+
+        try {
+            RetryStorageOperation.performRequestWithReinitCredentials(a);
+        } catch (ExecutorException e) {
+            throw new IOException(Messages.Download_DownloadException(), e);
+        } catch (InterruptedException e) {
+            throw new IOException(Messages.Download_DownloadException(), e);
+        }
+    }
+
+    private void initiateDownloadsAtWorkspace(
+            final GoogleRobotCredentials credentials,
+            final List<StorageObjectId> objects,
+            final FilePath localDir,
+            final TaskListener listener,
+            final String version,
+            final String resolvedPrefix)
+            throws IOException, InterruptedException {
+        try {
+            // Use remotable credential to access the storage service from the
+            // remote machine.
+            final GoogleRobotCredentials remoteCredentials =
+                    checkNotNull(credentials).forRemote(getModule().getRequirement());
+
+            localDir.act(new MasterToSlaveCallable<Void, IOException>() {
+                @Override
+                public Void call() throws IOException {
+                    performDownloads(remoteCredentials, localDir, objects, listener, version, resolvedPrefix);
+                    return (Void) null;
+                }
+            });
+        } catch (GeneralSecurityException e) {
+            throw new IOException(Messages.AbstractUpload_RemoteCredentialError(), e);
+        }
+    }
+
+    /** A class to store StorageObject information in a serializable manner. */
+    protected static class StorageObjectId implements Serializable {
+        public StorageObjectId(StorageObject obj) {
+            this.bucket = obj.getBucket();
+            this.name = obj.getName();
+        }
+
+        public String getBucket() {
+            return bucket;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        private final String bucket;
+        private final String name;
+    }
+
+    /**
+     * Split the string on wildcards ("*").
+     *
+     * <p>String.split removes trailing empty strings, for example, "a", "a*" and "a**" and would
+     * produce the same result, so that method is not suitable.
+     *
+     * @param uri URI supplied to be split.
+     * @return URI split by "*" wildcard.
+     * @throws AbortException If there is more than one wild card character in the provided string.
+     */
+    public static String[] split(String uri) throws AbortException {
+        int occurs = StringUtils.countMatches(uri, "*");
+
+        if (occurs == 0) {
+            return new String[] {uri};
+        }
+
+        if (occurs > 1) {
+            throw new AbortException(Messages.Download_UnsupportedMultipleAsterisks(uri));
+        }
+
+        int index = uri.indexOf('*');
+        return new String[] {uri.substring(0, index), uri.substring(index + 1)};
+    }
+
+    /** Verifies that the given path is supported within current limitations */
+    private static void verifySupported(BucketPath path) throws AbortException {
+        if (path.getBucket().contains("*")) {
+            throw new AbortException(Messages.Download_UnsupportedAsteriskInBucket(path.getBucket()));
+        }
+        String[] pieces = split(path.getObject());
+        if (pieces.length == 2) {
+            if (pieces[1].contains("/")) {
+                throw new AbortException(Messages.Download_UnsupportedDirSuffix(path.getObject()));
+            }
+        }
+    }
+
+    /**
+     * Take the bucket path and return a list of objects in the cloud that match it.
+     *
+     * <p>This will eventually handle wildcards, but for now is limited to directly specifying the
+     * object.
+     */
+    private List<StorageObjectId> resolveBucketPath(
+            BucketPath bucketPath, GoogleRobotCredentials credentials, String version)
+            throws IOException, ExecutorException {
+        Storage service = getModule().getStorageService(credentials, version);
+        Executor executor = getModule().newExecutor();
+
+        List<StorageObjectId> result = new ArrayList<StorageObjectId>();
+
+        verifySupported(bucketPath);
+
+        // Allow a single asterisk in the object name for now.
+        // Let the behavior be consistent with
+        // https://cloud.google.com/storage/docs/gsutil/addlhelp/WildcardNames
+        //
+        // Support for richer constructs will be added as needed.
+
+        String[] pieces = split(bucketPath.getObject());
+
+        if (pieces.length == 1) {
+            // No wildcards. Do simple lookup
+            Storage.Objects.Get obj = service.objects().get(bucketPath.getBucket(), bucketPath.getObject());
+
+            result.add(new StorageObjectId(executor.execute(obj)));
+
+            return result;
+        }
+
+        // Single wildcard, of the form pre/fix/log_*_some.txt
+
+        String bucketPathPrefix = pieces[0];
+        String bucketPathSuffix = pieces[1];
+
+        String pageToken = "";
+        do {
+            Storage.Objects.List list = service.objects()
+                    .list(bucketPath.getBucket())
+                    .setPrefix(bucketPathPrefix)
+                    .setDelimiter("/");
+            if (pageToken.length() > 0) {
+                list.setPageToken(pageToken);
+            }
+
+            Objects objects = executor.execute(list);
+            pageToken = objects.getNextPageToken();
+
+            // Collect the items that match the suffix
+            for (StorageObject o : objects.getItems()) {
+                if (o.getName().endsWith(bucketPathSuffix)) {
+                    result.add(new StorageObjectId(o));
+                }
+            }
+        } while (pageToken != null && pageToken.length() > 0);
+
+        return result;
+    }
+
+    /** {@inheritDoc} */
+    public DescriptorImpl getDescriptor() {
+        return (DescriptorImpl) checkNotNull(Jenkins.get()).getDescriptor(getClass());
+    }
+
+    /** Descriptor for the DownloadStep */
+    @Extension
+    @Symbol("googleStorageDownload")
+    public static class DescriptorImpl extends BuildStepDescriptor<Builder> {
+        private UploadModule module;
+
+        /**
+         * @return Module for the DescriptorImpl.
+         */
+        public synchronized UploadModule getModule() {
+            if (this.module == null) {
+                return new UploadModule();
+            }
+            return this.module;
+        }
+
+        /** Constructor for {@link DownloadStep}'s DescriptorImpl. */
+        public DescriptorImpl() {
+            this.module = new UploadModule();
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public String getDisplayName() {
+            return Messages.Download_BuildStepDisplayName();
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+            return true;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public Builder newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+            if (Boolean.FALSE.equals(formData.remove("stripPathPrefix"))) {
+                formData.remove("pathPrefix");
+            }
+            return super.newInstance(req, formData);
+        }
+
+        /**
+         * This callback validates the {@code bucketNameWithVars} input field's values.
+         *
+         * @param bucketUri Name of the GCS bucket. e.g. gs://MY_BUCKET_NAME
+         * @return Valid form validation result or error message if invalid.
+         */
+        public FormValidation doCheckBucketUri(@QueryParameter final String bucketUri) {
+            try {
+                BucketPath path = new BucketPath(bucketUri);
+                verifySupported(path);
+            } catch (AbortException e) {
+                return FormValidation.error(e.getMessage());
+            } catch (IllegalArgumentException e) {
+                return FormValidation.error(e.getMessage());
+            }
+
+            return ClassicUpload.DescriptorImpl.staticDoCheckBucket(bucketUri);
+        }
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/ExpiringBucketLifecycleManager.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/ExpiringBucketLifecycleManager.java
@@ -30,132 +30,130 @@ import org.kohsuke.stapler.DataBoundConstructor;
  * (aka TTL).
  */
 public class ExpiringBucketLifecycleManager extends AbstractBucketLifecycleManager {
-  private static final Logger logger =
-      Logger.getLogger(ExpiringBucketLifecycleManager.class.getName());
-  // NOTE: old name kept for deserialization
-  private final int bucketObjectTTL;
+    private static final Logger logger = Logger.getLogger(ExpiringBucketLifecycleManager.class.getName());
+    // NOTE: old name kept for deserialization
+    private final int bucketObjectTTL;
 
-  private static final String DELETE = "Delete";
+    private static final String DELETE = "Delete";
 
-  /**
-   * Construct the simple lifecycle manager from a TLL and the common properties.
-   *
-   * @param bucket GCS Bucket in which to alter the time to live.
-   * @param module Helper class methods to use for execution.
-   * @param ttl The number of days after which to delete data stored in the GCS bucket.
-   * @param bucketNameWithVars Legacy name for bucket. Deprecated.
-   * @param bucketObjectTTL Legacy name for ttl. Deprecated.
-   */
-  @DataBoundConstructor
-  public ExpiringBucketLifecycleManager(
-      String bucket,
-      @Nullable UploadModule module,
-      Integer ttl,
-      // Legacy arguments for backwards compatibility
-      @Deprecated @Nullable String bucketNameWithVars,
-      @Deprecated @Nullable Integer bucketObjectTTL) {
-    super(bucket != null ? bucket : bucketNameWithVars, module);
-    this.bucketObjectTTL = ttl != null ? ttl : bucketObjectTTL;
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public String getDetails() {
-    return Messages.ExpiringBucketLifecycleManager_DetailsMessage(getTtl());
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  protected Bucket checkBucket(Bucket bucket) throws InvalidAnnotationException {
-    Bucket.Lifecycle lifecycle = bucket.getLifecycle();
-    if (lifecycle == null) {
-      throw new InvalidAnnotationException(bucket);
-    }
-
-    if (lifecycle.getRule().size() != 1) {
-      // TODO(mattmoor): Consider allowing this plugin to augment, rather
-      // than replace existing lifecycle rules.
-      if (lifecycle.getRule().size() > 1) {
-        logger.log(WARNING, "Found complex lifecycle rule on: " + bucket.getName());
-      }
-      throw new InvalidAnnotationException(bucket);
-    }
-
-    for (Bucket.Lifecycle.Rule rule : lifecycle.getRule()) {
-      if (!rule.getAction().getType().equalsIgnoreCase(DELETE)) {
-        continue;
-      }
-      Bucket.Lifecycle.Rule.Condition condition = rule.getCondition();
-      if (condition.size() != 1) {
-        continue;
-      }
-      Integer age = condition.getAge();
-      if (age == null) {
-        continue;
-      }
-      if (age != getTtl()) {
-        continue;
-      }
-
-      return bucket;
-    }
-    logger.log(WARNING, "Mismatched lifecycle rule on: " + bucket.getName());
-    throw new InvalidAnnotationException(bucket);
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  protected Bucket decorateBucket(Bucket bucket) {
-    Bucket.Lifecycle.Rule rule =
-        new Bucket.Lifecycle.Rule()
-            .setCondition(new Bucket.Lifecycle.Rule.Condition().setAge(getTtl())) // age is in days
-            .setAction(new Bucket.Lifecycle.Rule.Action().setType(DELETE));
-
-    List<Bucket.Lifecycle.Rule> rules = Lists.newArrayList();
-
-    // TODO(mattmoor): Consider allowing this plugin to augment, rather
-    // than replace existing lifecycle rules.
-    // NOTE: This would require us to ~filter out incompatible clauses.
-    //
-    // Bucket.Lifecycle lifecycle = bucket.getLifecycle();
-    // if (lifecycle != null) {
-    //   if (lifecycle.getRule() != null) {
-    //     rules.addAll(lifecycle.getRule());
-    //   }
-    // }
-
-    // Add our new rule
-    rules.add(rule);
-
-    // Put the newly composed set of rules into the lifecycle of the bucket
-    bucket.setLifecycle(new Bucket.Lifecycle().setRule(rules));
-
-    return bucket;
-  }
-
-  /**
-   * @return Surface the TTL for objects contained within the bucket for roundtripping to the jelly
-   *     UI.
-   */
-  public int getTtl() {
-    return bucketObjectTTL;
-  }
-
-  /** Denotes this is an {@link AbstractUpload} plugin */
-  @Extension
-  public static class DescriptorImpl extends AbstractBucketLifecycleManagerDescriptor {
-    public DescriptorImpl() {
-      this(ExpiringBucketLifecycleManager.class);
-    }
-
-    public DescriptorImpl(Class<? extends ExpiringBucketLifecycleManager> clazz) {
-      super(clazz);
+    /**
+     * Construct the simple lifecycle manager from a TLL and the common properties.
+     *
+     * @param bucket GCS Bucket in which to alter the time to live.
+     * @param module Helper class methods to use for execution.
+     * @param ttl The number of days after which to delete data stored in the GCS bucket.
+     * @param bucketNameWithVars Legacy name for bucket. Deprecated.
+     * @param bucketObjectTTL Legacy name for ttl. Deprecated.
+     */
+    @DataBoundConstructor
+    public ExpiringBucketLifecycleManager(
+            String bucket,
+            @Nullable UploadModule module,
+            Integer ttl,
+            // Legacy arguments for backwards compatibility
+            @Deprecated @Nullable String bucketNameWithVars,
+            @Deprecated @Nullable Integer bucketObjectTTL) {
+        super(bucket != null ? bucket : bucketNameWithVars, module);
+        this.bucketObjectTTL = ttl != null ? ttl : bucketObjectTTL;
     }
 
     /** {@inheritDoc} */
     @Override
-    public String getDisplayName() {
-      return Messages.ExpiringBucketLifecycleManager_DisplayName();
+    public String getDetails() {
+        return Messages.ExpiringBucketLifecycleManager_DetailsMessage(getTtl());
     }
-  }
+
+    /** {@inheritDoc} */
+    @Override
+    protected Bucket checkBucket(Bucket bucket) throws InvalidAnnotationException {
+        Bucket.Lifecycle lifecycle = bucket.getLifecycle();
+        if (lifecycle == null) {
+            throw new InvalidAnnotationException(bucket);
+        }
+
+        if (lifecycle.getRule().size() != 1) {
+            // TODO(mattmoor): Consider allowing this plugin to augment, rather
+            // than replace existing lifecycle rules.
+            if (lifecycle.getRule().size() > 1) {
+                logger.log(WARNING, "Found complex lifecycle rule on: " + bucket.getName());
+            }
+            throw new InvalidAnnotationException(bucket);
+        }
+
+        for (Bucket.Lifecycle.Rule rule : lifecycle.getRule()) {
+            if (!rule.getAction().getType().equalsIgnoreCase(DELETE)) {
+                continue;
+            }
+            Bucket.Lifecycle.Rule.Condition condition = rule.getCondition();
+            if (condition.size() != 1) {
+                continue;
+            }
+            Integer age = condition.getAge();
+            if (age == null) {
+                continue;
+            }
+            if (age != getTtl()) {
+                continue;
+            }
+
+            return bucket;
+        }
+        logger.log(WARNING, "Mismatched lifecycle rule on: " + bucket.getName());
+        throw new InvalidAnnotationException(bucket);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    protected Bucket decorateBucket(Bucket bucket) {
+        Bucket.Lifecycle.Rule rule = new Bucket.Lifecycle.Rule()
+                .setCondition(new Bucket.Lifecycle.Rule.Condition().setAge(getTtl())) // age is in days
+                .setAction(new Bucket.Lifecycle.Rule.Action().setType(DELETE));
+
+        List<Bucket.Lifecycle.Rule> rules = Lists.newArrayList();
+
+        // TODO(mattmoor): Consider allowing this plugin to augment, rather
+        // than replace existing lifecycle rules.
+        // NOTE: This would require us to ~filter out incompatible clauses.
+        //
+        // Bucket.Lifecycle lifecycle = bucket.getLifecycle();
+        // if (lifecycle != null) {
+        //   if (lifecycle.getRule() != null) {
+        //     rules.addAll(lifecycle.getRule());
+        //   }
+        // }
+
+        // Add our new rule
+        rules.add(rule);
+
+        // Put the newly composed set of rules into the lifecycle of the bucket
+        bucket.setLifecycle(new Bucket.Lifecycle().setRule(rules));
+
+        return bucket;
+    }
+
+    /**
+     * @return Surface the TTL for objects contained within the bucket for roundtripping to the jelly
+     *     UI.
+     */
+    public int getTtl() {
+        return bucketObjectTTL;
+    }
+
+    /** Denotes this is an {@link AbstractUpload} plugin */
+    @Extension
+    public static class DescriptorImpl extends AbstractBucketLifecycleManagerDescriptor {
+        public DescriptorImpl() {
+            this(ExpiringBucketLifecycleManager.class);
+        }
+
+        public DescriptorImpl(Class<? extends ExpiringBucketLifecycleManager> clazz) {
+            super(clazz);
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public String getDisplayName() {
+            return Messages.ExpiringBucketLifecycleManager_DisplayName();
+        }
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/ExpiringBucketLifecycleManagerStep.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/ExpiringBucketLifecycleManagerStep.java
@@ -41,99 +41,98 @@ import org.kohsuke.stapler.QueryParameter;
  * post step.
  */
 @RequiresDomain(StorageScopeRequirement.class)
-public class ExpiringBucketLifecycleManagerStep extends Recorder
-    implements SimpleBuildStep, Serializable {
-  private ExpiringBucketLifecycleManager upload;
-  private final String credentialsId;
+public class ExpiringBucketLifecycleManagerStep extends Recorder implements SimpleBuildStep, Serializable {
+    private ExpiringBucketLifecycleManager upload;
+    private final String credentialsId;
 
-  /**
-   * Constructs a new {@link ExpiringBucketLifecycleManagerStep}.
-   *
-   * @param credentialsId The credentials to utilize for authenticating with GCS.
-   * @param bucket GCS Bucket in which to alter the time to live.
-   * @param ttl The number of days after which to delete data stored in the GCS bucket.
-   */
-  @DataBoundConstructor
-  public ExpiringBucketLifecycleManagerStep(String credentialsId, String bucket, Integer ttl) {
-    this(credentialsId, bucket, Optional.ofNullable(null), ttl);
-  }
-
-  /**
-   * Construct the ExpiringBucketLifecycleManager uploader to use the provided credentials to set
-   * number of days after which to delete data stored in the specified GCS bucket.
-   *
-   * @param credentialsId The credentials to utilize for authenticating with GCS.
-   * @param bucket GCS Bucket in which to alter the time to live.
-   * @param module Helper class for connecting to the GCS API.
-   * @param ttl The number of days after which to delete data stored in the GCS bucket.
-   */
-  public ExpiringBucketLifecycleManagerStep(
-      String credentialsId, String bucket, Optional<UploadModule> module, Integer ttl) {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(credentialsId));
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(bucket));
-    Preconditions.checkNotNull(ttl);
-    this.credentialsId = credentialsId;
-    upload = new ExpiringBucketLifecycleManager(bucket, module.orElse(null), ttl, null, null);
-  }
-
-  /**
-   * @return The unique ID for the credentials we are using to authenticate with GCS.
-   */
-  public String getCredentialsId() {
-    return credentialsId;
-  }
-
-  /**
-   * @return Name of our GCS bucket.
-   */
-  public String getBucket() {
-    return upload.getBucket();
-  }
-
-  /**
-   * @return Surface the TTL for objects contained within the bucket for roundtripping to the jelly
-   *     UI.
-   */
-  public int getTtl() {
-    return upload.getTtl();
-  }
-
-  /** {@inheritDoc} * */
-  @Override
-  public void perform(Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener listener)
-      throws IOException {
-    try {
-      upload.perform(getCredentialsId(), run, workspace, listener);
-    } catch (UploadException e) {
-      throw new IOException(Messages.ExpiringBucketLifecycleManager_FailToSetExpiration(), e);
-    }
-  }
-
-  /** Descriptor for {@link ExpiringBucketLifecycleManagerStep} */
-  @Extension
-  @Symbol("googleStorageBucketLifecycle")
-  public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
-    /** {@inheritDoc} */
-    @Override
-    public String getDisplayName() {
-      return Messages.ExpiringBucketLifecycleManager_BuildStepDisplayName();
-    }
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean isApplicable(Class<? extends AbstractProject> jobType) {
-      return true;
+    /**
+     * Constructs a new {@link ExpiringBucketLifecycleManagerStep}.
+     *
+     * @param credentialsId The credentials to utilize for authenticating with GCS.
+     * @param bucket GCS Bucket in which to alter the time to live.
+     * @param ttl The number of days after which to delete data stored in the GCS bucket.
+     */
+    @DataBoundConstructor
+    public ExpiringBucketLifecycleManagerStep(String credentialsId, String bucket, Integer ttl) {
+        this(credentialsId, bucket, Optional.ofNullable(null), ttl);
     }
 
     /**
-     * This callback validates the {@code bucket} input field's values.
+     * Construct the ExpiringBucketLifecycleManager uploader to use the provided credentials to set
+     * number of days after which to delete data stored in the specified GCS bucket.
      *
+     * @param credentialsId The credentials to utilize for authenticating with GCS.
      * @param bucket GCS Bucket in which to alter the time to live.
-     * @return Valid form validation result or error message if invalid.
-     * @throws IOException If there was an issue validating the bucket provided.
+     * @param module Helper class for connecting to the GCS API.
+     * @param ttl The number of days after which to delete data stored in the GCS bucket.
      */
-    public FormValidation doCheckBucket(@QueryParameter final String bucket) throws IOException {
-      return ExpiringBucketLifecycleManager.DescriptorImpl.staticDoCheckBucket(bucket);
+    public ExpiringBucketLifecycleManagerStep(
+            String credentialsId, String bucket, Optional<UploadModule> module, Integer ttl) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(credentialsId));
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(bucket));
+        Preconditions.checkNotNull(ttl);
+        this.credentialsId = credentialsId;
+        upload = new ExpiringBucketLifecycleManager(bucket, module.orElse(null), ttl, null, null);
     }
-  }
+
+    /**
+     * @return The unique ID for the credentials we are using to authenticate with GCS.
+     */
+    public String getCredentialsId() {
+        return credentialsId;
+    }
+
+    /**
+     * @return Name of our GCS bucket.
+     */
+    public String getBucket() {
+        return upload.getBucket();
+    }
+
+    /**
+     * @return Surface the TTL for objects contained within the bucket for roundtripping to the jelly
+     *     UI.
+     */
+    public int getTtl() {
+        return upload.getTtl();
+    }
+
+    /** {@inheritDoc} * */
+    @Override
+    public void perform(Run<?, ?> run, FilePath workspace, Launcher launcher, TaskListener listener)
+            throws IOException {
+        try {
+            upload.perform(getCredentialsId(), run, workspace, listener);
+        } catch (UploadException e) {
+            throw new IOException(Messages.ExpiringBucketLifecycleManager_FailToSetExpiration(), e);
+        }
+    }
+
+    /** Descriptor for {@link ExpiringBucketLifecycleManagerStep} */
+    @Extension
+    @Symbol("googleStorageBucketLifecycle")
+    public static class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+        /** {@inheritDoc} */
+        @Override
+        public String getDisplayName() {
+            return Messages.ExpiringBucketLifecycleManager_BuildStepDisplayName();
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+            return true;
+        }
+
+        /**
+         * This callback validates the {@code bucket} input field's values.
+         *
+         * @param bucket GCS Bucket in which to alter the time to live.
+         * @return Valid form validation result or error message if invalid.
+         * @throws IOException If there was an issue validating the bucket provided.
+         */
+        public FormValidation doCheckBucket(@QueryParameter final String bucket) throws IOException {
+            return ExpiringBucketLifecycleManager.DescriptorImpl.staticDoCheckBucket(bucket);
+        }
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/GoogleCloudStorageUploader.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/GoogleCloudStorageUploader.java
@@ -44,122 +44,118 @@ import org.kohsuke.stapler.DataBoundConstructor;
 /** A Jenkins plugin for uploading files to Google Cloud Storage (GCS). */
 @RequiresDomain(value = StorageScopeRequirement.class)
 public class GoogleCloudStorageUploader extends Recorder {
-  private final String credentialsId;
-  private final List<AbstractUpload> uploads;
+    private final String credentialsId;
+    private final List<AbstractUpload> uploads;
 
-  /**
-   * Construct the GCS uploader to use the provided credentials to upload build artifacts.
-   *
-   * @param credentialsId The credentials to utilize for authenticating with GCS
-   * @param uploads The list of uploads the user has requested be done
-   */
-  @DataBoundConstructor
-  public GoogleCloudStorageUploader(String credentialsId, @Nullable List<AbstractUpload> uploads) {
-    this.credentialsId = checkNotNull(credentialsId);
-    if (uploads == null) {
-      this.uploads = ImmutableList.<AbstractUpload>of();
-    } else {
-      checkArgument(uploads.size() > 0);
-      this.uploads = uploads;
+    /**
+     * Construct the GCS uploader to use the provided credentials to upload build artifacts.
+     *
+     * @param credentialsId The credentials to utilize for authenticating with GCS
+     * @param uploads The list of uploads the user has requested be done
+     */
+    @DataBoundConstructor
+    public GoogleCloudStorageUploader(String credentialsId, @Nullable List<AbstractUpload> uploads) {
+        this.credentialsId = checkNotNull(credentialsId);
+        if (uploads == null) {
+            this.uploads = ImmutableList.<AbstractUpload>of();
+        } else {
+            checkArgument(uploads.size() > 0);
+            this.uploads = uploads;
+        }
     }
-  }
 
-  /**
-   * @return The unique ID for the credentials we are using to authenticate with GCS.
-   */
-  public String getCredentialsId() {
-    return credentialsId;
-  }
-
-  /**
-   * @return The credentials we are using to authenticate with GCS.
-   */
-  public GoogleRobotCredentials getCredentials() {
-    return GoogleRobotCredentials.getById(getCredentialsId());
-  }
-
-  /**
-   * @return The set of tuples describing the artifacts to upload, and where to upload them.
-   */
-  public Collection<AbstractUpload> getUploads() {
-    return Collections.unmodifiableCollection(uploads);
-  }
-
-  /** {@inheritDoc} */
-  @Override
-  public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
-      throws IOException, InterruptedException {
-    // TODO(mattmoor): threadpool?
-    boolean result = true;
-    for (AbstractUpload upload : uploads) {
-      try {
-        upload.perform(getCredentialsId(), build, listener);
-      } catch (UploadException e) {
-        e.printStackTrace(
-            listener.error(
-                Messages.StorageUtil_PrefixFormat(
-                    getDescriptor().getDisplayName(),
-                    Messages.GoogleCloudStorageUploader_ExceptionDuringUpload(e.getMessage()))));
-        build.setResult(Result.FAILURE);
-        result = false;
-      }
+    /**
+     * @return The unique ID for the credentials we are using to authenticate with GCS.
+     */
+    public String getCredentialsId() {
+        return credentialsId;
     }
-    return result;
-  }
 
-  /** {@inheritDoc} */
-  @Override
-  public BuildStepMonitor getRequiredMonitorService() {
-    return BuildStepMonitor.NONE;
-  }
+    /**
+     * @return The credentials we are using to authenticate with GCS.
+     */
+    public GoogleRobotCredentials getCredentials() {
+        return GoogleRobotCredentials.getById(getCredentialsId());
+    }
 
-  /** {@inheritDoc} */
-  @Override
-  public DescriptorImpl getDescriptor() {
-    return (DescriptorImpl) super.getDescriptor();
-  }
-
-  /** Descriptor for the extension for uploading build artifacts to Google Cloud Storage. */
-  @Extension
-  public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
-
-    /** {@inheritDoc} */
-    @Override
-    public boolean isApplicable(
-        @SuppressWarnings("rawtypes") Class<? extends AbstractProject> aClass) {
-      // Indicates that this builder can be used with all kinds of project types
-      return true;
+    /**
+     * @return The set of tuples describing the artifacts to upload, and where to upload them.
+     */
+    public Collection<AbstractUpload> getUploads() {
+        return Collections.unmodifiableCollection(uploads);
     }
 
     /** {@inheritDoc} */
     @Override
-    public String getDisplayName() {
-      return Messages.GoogleCloudStorageUploader_DisplayName();
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener)
+            throws IOException, InterruptedException {
+        // TODO(mattmoor): threadpool?
+        boolean result = true;
+        for (AbstractUpload upload : uploads) {
+            try {
+                upload.perform(getCredentialsId(), build, listener);
+            } catch (UploadException e) {
+                e.printStackTrace(listener.error(Messages.StorageUtil_PrefixFormat(
+                        getDescriptor().getDisplayName(),
+                        Messages.GoogleCloudStorageUploader_ExceptionDuringUpload(e.getMessage()))));
+                build.setResult(Result.FAILURE);
+                result = false;
+            }
+        }
+        return result;
     }
 
-    /**
-     * @return the default uploads when the user configure {@link GoogleCloudStorageUploader} for
-     *     the first time.
-     */
-    public List<AbstractUpload> getDefaultUploads() {
-      StdoutUpload upload =
-          new StdoutUpload(
-              GCS_SCHEME, null, "build-log.txt", null /* legacy arg: bucketNameWithVars */);
-      upload.setForFailedJobs(true);
-      return ImmutableList.<AbstractUpload>of(upload);
+    /** {@inheritDoc} */
+    @Override
+    public BuildStepMonitor getRequiredMonitorService() {
+        return BuildStepMonitor.NONE;
     }
 
-    /**
-     * @return All registered {@link AbstractUpload}s.
-     */
-    public List<AbstractUploadDescriptor> getUploads() {
-      return AbstractUpload.all();
+    /** {@inheritDoc} */
+    @Override
+    public DescriptorImpl getDescriptor() {
+        return (DescriptorImpl) super.getDescriptor();
     }
-  }
 
-  /** {@inheritDoc} */
-  @Override
-  public Action getProjectAction(AbstractProject<?, ?> project) {
-    return new ProjectGcsUploadReport(project);
-  }
+    /** Descriptor for the extension for uploading build artifacts to Google Cloud Storage. */
+    @Extension
+    public static final class DescriptorImpl extends BuildStepDescriptor<Publisher> {
+
+        /** {@inheritDoc} */
+        @Override
+        public boolean isApplicable(@SuppressWarnings("rawtypes") Class<? extends AbstractProject> aClass) {
+            // Indicates that this builder can be used with all kinds of project types
+            return true;
+        }
+
+        /** {@inheritDoc} */
+        @Override
+        public String getDisplayName() {
+            return Messages.GoogleCloudStorageUploader_DisplayName();
+        }
+
+        /**
+         * @return the default uploads when the user configure {@link GoogleCloudStorageUploader} for
+         *     the first time.
+         */
+        public List<AbstractUpload> getDefaultUploads() {
+            StdoutUpload upload =
+                    new StdoutUpload(GCS_SCHEME, null, "build-log.txt", null /* legacy arg: bucketNameWithVars */);
+            upload.setForFailedJobs(true);
+            return ImmutableList.<AbstractUpload>of(upload);
+        }
+
+        /**
+         * @return All registered {@link AbstractUpload}s.
+         */
+        public List<AbstractUploadDescriptor> getUploads() {
+            return AbstractUpload.all();
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Action getProjectAction(AbstractProject<?, ?> project) {
+        return new ProjectGcsUploadReport(project);
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/HttpHeaders.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/HttpHeaders.java
@@ -19,69 +19,67 @@ import com.google.common.base.Charsets;
 
 /** Utility class for building HTTP header values. */
 public class HttpHeaders {
-  private static final String RFC_5987_ATTR_CHARS = "!#$&+-.^_`|~";
+    private static final String RFC_5987_ATTR_CHARS = "!#$&+-.^_`|~";
 
-  /**
-   * Returns an RFC 6266 Content-Disposition header for the given filename.
-   *
-   * @param filename Name of the file to get the Content-Disposition header for.
-   * @param showInline If the content should be displayed inline or as an attachment.
-   * @return The RFC 6266 Content-Disposition header for the filename.
-   */
-  public static String getContentDisposition(String filename, boolean showInline) {
-    return String.format(
-        "%s; filename=%s; filename*=%s",
-        showInline ? "inline" : "attachment",
-        getRfc2616QuotedString(filename),
-        getRfc5987ExtValue(filename));
-  }
-
-  /**
-   * Returns an RFC 2616 quoted-string encoding of the given text. Code points &lt;= U+255 will be
-   * encoded, others will be zapped to underscore.
-   */
-  private static String getRfc2616QuotedString(String text) {
-    StringBuilder builder = new StringBuilder("\"");
-    for (int i = 0; i < text.length(); ) {
-      int codePoint = text.codePointAt(i);
-      i += Character.charCount(codePoint);
-      if (codePoint == '"') {
-        builder.append("\\\"");
-      } else if (codePoint == '\\') {
-        builder.append("\\\\");
-      } else if (codePoint <= 255) {
-        // Assumes the remote side will interpret as ISO-8859-1.
-        builder.appendCodePoint(codePoint);
-      } else {
-        builder.append('_');
-      }
+    /**
+     * Returns an RFC 6266 Content-Disposition header for the given filename.
+     *
+     * @param filename Name of the file to get the Content-Disposition header for.
+     * @param showInline If the content should be displayed inline or as an attachment.
+     * @return The RFC 6266 Content-Disposition header for the filename.
+     */
+    public static String getContentDisposition(String filename, boolean showInline) {
+        return String.format(
+                "%s; filename=%s; filename*=%s",
+                showInline ? "inline" : "attachment", getRfc2616QuotedString(filename), getRfc5987ExtValue(filename));
     }
-    return builder.append('"').toString();
-  }
 
-  /**
-   * Returns an RFC 5987 ext-value encoding of the given text, with charset UTF-8 and no language
-   * tag.
-   */
-  private static String getRfc5987ExtValue(String text) {
-    StringBuilder builder = new StringBuilder("UTF-8''");
-    for (int i = 0; i < text.length(); ) {
-      int codePoint = text.codePointAt(i);
-      int len = Character.charCount(codePoint);
-      if ((codePoint >= '0' && codePoint <= '9')
-          || (codePoint >= 'A' && codePoint <= 'Z')
-          || (codePoint >= 'a' && codePoint <= 'z')
-          || (RFC_5987_ATTR_CHARS.indexOf(codePoint) != -1)) {
-        builder.appendCodePoint(codePoint);
-      } else {
-        for (byte b : text.substring(i, i + len).getBytes(Charsets.UTF_8)) {
-          builder.append(String.format("%%%02X", ((int) b) & 0xff));
+    /**
+     * Returns an RFC 2616 quoted-string encoding of the given text. Code points &lt;= U+255 will be
+     * encoded, others will be zapped to underscore.
+     */
+    private static String getRfc2616QuotedString(String text) {
+        StringBuilder builder = new StringBuilder("\"");
+        for (int i = 0; i < text.length(); ) {
+            int codePoint = text.codePointAt(i);
+            i += Character.charCount(codePoint);
+            if (codePoint == '"') {
+                builder.append("\\\"");
+            } else if (codePoint == '\\') {
+                builder.append("\\\\");
+            } else if (codePoint <= 255) {
+                // Assumes the remote side will interpret as ISO-8859-1.
+                builder.appendCodePoint(codePoint);
+            } else {
+                builder.append('_');
+            }
         }
-      }
-      i += len;
+        return builder.append('"').toString();
     }
-    return builder.toString();
-  }
 
-  private HttpHeaders() {}
+    /**
+     * Returns an RFC 5987 ext-value encoding of the given text, with charset UTF-8 and no language
+     * tag.
+     */
+    private static String getRfc5987ExtValue(String text) {
+        StringBuilder builder = new StringBuilder("UTF-8''");
+        for (int i = 0; i < text.length(); ) {
+            int codePoint = text.codePointAt(i);
+            int len = Character.charCount(codePoint);
+            if ((codePoint >= '0' && codePoint <= '9')
+                    || (codePoint >= 'A' && codePoint <= 'Z')
+                    || (codePoint >= 'a' && codePoint <= 'z')
+                    || (RFC_5987_ATTR_CHARS.indexOf(codePoint) != -1)) {
+                builder.appendCodePoint(codePoint);
+            } else {
+                for (byte b : text.substring(i, i + len).getBytes(Charsets.UTF_8)) {
+                    builder.append(String.format("%%%02X", ((int) b) & 0xff));
+                }
+            }
+            i += len;
+        }
+        return builder.toString();
+    }
+
+    private HttpHeaders() {}
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/InvalidAnnotationException.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/InvalidAnnotationException.java
@@ -24,21 +24,21 @@ import com.google.api.services.storage.model.Bucket;
  * AbstractBucketLifecycleManager#checkBucket} when a bucket is not properly annotated.
  */
 public class InvalidAnnotationException extends Exception {
-  /**
-   * Constructor for the exception.
-   *
-   * @param bucket Name of the GCS bucket.
-   */
-  public InvalidAnnotationException(Bucket bucket) {
-    this.bucket = checkNotNull(bucket);
-  }
+    /**
+     * Constructor for the exception.
+     *
+     * @param bucket Name of the GCS bucket.
+     */
+    public InvalidAnnotationException(Bucket bucket) {
+        this.bucket = checkNotNull(bucket);
+    }
 
-  /**
-   * @return The bucket that isn't properly annotated.
-   */
-  public Bucket getBucket() {
-    return this.bucket;
-  }
+    /**
+     * @return The bucket that isn't properly annotated.
+     */
+    public Bucket getBucket() {
+        return this.bucket;
+    }
 
-  private final Bucket bucket;
+    private final Bucket bucket;
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/StorageScopeRequirement.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/StorageScopeRequirement.java
@@ -22,9 +22,9 @@ import java.util.Collection;
 
 /** The required OAuth2 scopes for managing Google Cloud Storage buckets and objects. */
 public class StorageScopeRequirement extends GoogleOAuth2ScopeRequirement {
-  /** {@inheritDoc} */
-  @Override
-  public Collection<String> getScopes() {
-    return ImmutableList.of(StorageScopes.DEVSTORAGE_FULL_CONTROL);
-  }
+    /** {@inheritDoc} */
+    @Override
+    public Collection<String> getScopes() {
+        return ImmutableList.of(StorageScopes.DEVSTORAGE_FULL_CONTROL);
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/UploadException.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/UploadException.java
@@ -17,14 +17,14 @@ package com.google.jenkins.plugins.storage;
 
 /** The class of exceptions that occur during actions of {@link AbstractUpload}s */
 public class UploadException extends Exception {
-  // Generated serial version ID.
-  private static final long serialVersionUID = 3255684370490910421L;
+    // Generated serial version ID.
+    private static final long serialVersionUID = 3255684370490910421L;
 
-  public UploadException(String message) {
-    super(message);
-  }
+    public UploadException(String message) {
+        super(message);
+    }
 
-  public UploadException(String message, Throwable cause) {
-    super(message, cause);
-  }
+    public UploadException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/UploadModule.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/UploadModule.java
@@ -36,91 +36,89 @@ import jenkins.model.Jenkins;
  */
 @RequiresDomain(value = StorageScopeRequirement.class)
 public class UploadModule {
-  private static final String PLUGIN_NAME = "google-storage-plugin";
-  /**
-   * Interface for requesting the {@link Executor} for executing requests.
-   *
-   * @return a new {@link Executor} instance for issuing requests.
-   */
-  public Executor newExecutor() {
-    return new Executor.Default();
-  }
-
-  /**
-   * Returns the scope requirement to access the GCS API.
-   *
-   * @return Storage scope requirement for the GCS API.
-   */
-  public StorageScopeRequirement getRequirement() {
-    return DomainRequirementProvider.of(getClass(), StorageScopeRequirement.class);
-  }
-
-  /**
-   * @return the version number of this plugin.
-   */
-  public String getVersion() {
-    String version = "";
-    Plugin plugin = Jenkins.get().getPlugin(PLUGIN_NAME);
-    if (plugin != null) {
-      version = plugin.getWrapper().getVersion();
+    private static final String PLUGIN_NAME = "google-storage-plugin";
+    /**
+     * Interface for requesting the {@link Executor} for executing requests.
+     *
+     * @return a new {@link Executor} instance for issuing requests.
+     */
+    public Executor newExecutor() {
+        return new Executor.Default();
     }
-    return version;
-  }
 
-  /**
-   * Given GoogleRobotCredentials and plugin version, return a handle to a Storage object that has
-   * already been authenticated.
-   *
-   * @param credentials Credentials needed to authenticate to the GCS API.
-   * @param version Current version of the plugin.
-   * @return Handle to a Storage object that has already been authenticated.
-   * @throws IOException If there is an issue authenticating with the given credentials.
-   */
-  public Storage getStorageService(GoogleRobotCredentials credentials, String version)
-      throws IOException {
-    try {
-      String appName = Messages.UploadModule_AppName();
-      if (version.length() > 0) {
-        version = version.split(" ")[0];
-        appName = appName.concat("/").concat(version);
-      }
-      return new Storage.Builder(
-              new NetHttpTransport(),
-              new JacksonFactory(),
-              credentials.getGoogleCredential(getRequirement()))
-          .setApplicationName(appName)
-          .build();
-    } catch (GeneralSecurityException e) {
-      throw new IOException(Messages.UploadModule_ExceptionStorageService(), e);
+    /**
+     * Returns the scope requirement to access the GCS API.
+     *
+     * @return Storage scope requirement for the GCS API.
+     */
+    public StorageScopeRequirement getRequirement() {
+        return DomainRequirementProvider.of(getClass(), StorageScopeRequirement.class);
     }
-  }
 
-  /**
-   * @return Controls the number of object insertion retries.
-   */
-  public int getInsertRetryCount() {
-    return 5;
-  }
+    /**
+     * @return the version number of this plugin.
+     */
+    public String getVersion() {
+        String version = "";
+        Plugin plugin = Jenkins.get().getPlugin(PLUGIN_NAME);
+        if (plugin != null) {
+            version = plugin.getWrapper().getVersion();
+        }
+        return version;
+    }
 
-  /**
-   * Prefix the given log message with our module name.
-   *
-   * @param logMessage Log message to log.
-   * @return Log message prefixed with module name.
-   */
-  public String prefix(String logMessage) {
-    return Messages.StorageUtil_PrefixFormat(
-        Messages.GoogleCloudStorageUploader_DisplayName(), logMessage);
-  }
+    /**
+     * Given GoogleRobotCredentials and plugin version, return a handle to a Storage object that has
+     * already been authenticated.
+     *
+     * @param credentials Credentials needed to authenticate to the GCS API.
+     * @param version Current version of the plugin.
+     * @return Handle to a Storage object that has already been authenticated.
+     * @throws IOException If there is an issue authenticating with the given credentials.
+     */
+    public Storage getStorageService(GoogleRobotCredentials credentials, String version) throws IOException {
+        try {
+            String appName = Messages.UploadModule_AppName();
+            if (version.length() > 0) {
+                version = version.split(" ")[0];
+                appName = appName.concat("/").concat(version);
+            }
+            return new Storage.Builder(
+                            new NetHttpTransport(),
+                            new JacksonFactory(),
+                            credentials.getGoogleCredential(getRequirement()))
+                    .setApplicationName(appName)
+                    .build();
+        } catch (GeneralSecurityException e) {
+            throw new IOException(Messages.UploadModule_ExceptionStorageService(), e);
+        }
+    }
 
-  /**
-   * Returns an InputStream for the given GCS object.
-   *
-   * @param getObject GCS object.
-   * @return GCS object in InputStream format.
-   * @throws IOException If there was in issue getting the InputStream for the GCS object.
-   */
-  public InputStream executeMediaAsInputStream(Storage.Objects.Get getObject) throws IOException {
-    return getObject.executeMediaAsInputStream();
-  }
+    /**
+     * @return Controls the number of object insertion retries.
+     */
+    public int getInsertRetryCount() {
+        return 5;
+    }
+
+    /**
+     * Prefix the given log message with our module name.
+     *
+     * @param logMessage Log message to log.
+     * @return Log message prefixed with module name.
+     */
+    public String prefix(String logMessage) {
+        return Messages.StorageUtil_PrefixFormat(Messages.GoogleCloudStorageUploader_DisplayName(), logMessage);
+    }
+
+    /**
+     * Returns an InputStream for the given GCS object.
+     *
+     * @param getObject GCS object.
+     * @return GCS object in InputStream format.
+     * @throws IOException If there was in issue getting the InputStream for the GCS object.
+     */
+    public InputStream executeMediaAsInputStream(Storage.Objects.Get getObject) throws IOException {
+        return getObject.executeMediaAsInputStream();
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/client/RetryHttpInitializerWrapper.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/client/RetryHttpInitializerWrapper.java
@@ -36,61 +36,59 @@ import java.util.logging.Logger;
  * href="https://github.com/GoogleCloudPlatform/java-docs-samples/blob/master/storage/storage-transfer/src/main/java/com/google/cloud/storage/storagetransfer/samples/RetryHttpInitializerWrapper.java">RetryHttpInitializerWrapper.java</a>
  */
 public class RetryHttpInitializerWrapper implements HttpRequestInitializer {
-  private static final Logger LOG = Logger.getLogger(RetryHttpInitializerWrapper.class.getName());
-  private static final int MILLIS_PER_MINUTE = 60 * 1000;
-  private final Credential wrappedCredential;
-  private final Sleeper sleeper;
+    private static final Logger LOG = Logger.getLogger(RetryHttpInitializerWrapper.class.getName());
+    private static final int MILLIS_PER_MINUTE = 60 * 1000;
+    private final Credential wrappedCredential;
+    private final Sleeper sleeper;
 
-  /**
-   * A constructor using the default Sleeper.
-   *
-   * @param wrappedCredential the credential used to authenticate with a Google Cloud Platform
-   *     project
-   */
-  public RetryHttpInitializerWrapper(Credential wrappedCredential) {
-    this(wrappedCredential, Sleeper.DEFAULT);
-  }
+    /**
+     * A constructor using the default Sleeper.
+     *
+     * @param wrappedCredential the credential used to authenticate with a Google Cloud Platform
+     *     project
+     */
+    public RetryHttpInitializerWrapper(Credential wrappedCredential) {
+        this(wrappedCredential, Sleeper.DEFAULT);
+    }
 
-  /**
-   * A constructor used only for testing.
-   *
-   * @param wrappedCredential the credential used to authenticate with a project
-   * @param sleeper a user-supplied Sleeper
-   */
-  RetryHttpInitializerWrapper(Credential wrappedCredential, Sleeper sleeper) {
-    this.wrappedCredential = Preconditions.checkNotNull(wrappedCredential);
-    this.sleeper = sleeper;
-  }
+    /**
+     * A constructor used only for testing.
+     *
+     * @param wrappedCredential the credential used to authenticate with a project
+     * @param sleeper a user-supplied Sleeper
+     */
+    RetryHttpInitializerWrapper(Credential wrappedCredential, Sleeper sleeper) {
+        this.wrappedCredential = Preconditions.checkNotNull(wrappedCredential);
+        this.sleeper = sleeper;
+    }
 
-  /**
-   * Initialize an HttpRequest.
-   *
-   * @param request an HttpRequest that should be initialized.
-   */
-  public void initialize(HttpRequest request) {
-    request.setReadTimeout(2 * MILLIS_PER_MINUTE); // 2 minutes read timeout
-    final HttpUnsuccessfulResponseHandler backoffHandler =
-        new HttpBackOffUnsuccessfulResponseHandler(new ExponentialBackOff()).setSleeper(sleeper);
-    request.setInterceptor(wrappedCredential);
-    request.setUnsuccessfulResponseHandler(
-        new HttpUnsuccessfulResponseHandler() {
-          public boolean handleResponse(
-              final HttpRequest request, final HttpResponse response, final boolean supportsRetry)
-              throws IOException {
-            if (wrappedCredential.handleResponse(request, response, supportsRetry)) {
-              // If credential decides it can handle it, the return code or message indicated
-              // something specific to authentication, and no backoff is desired.
-              return true;
-            } else if (backoffHandler.handleResponse(request, response, supportsRetry)) {
-              // Otherwise, we defer to the judgement of our internal backoff handler.
-              LOG.info("Retrying " + request.getUrl().toString());
-              return true;
-            } else {
-              return false;
+    /**
+     * Initialize an HttpRequest.
+     *
+     * @param request an HttpRequest that should be initialized.
+     */
+    public void initialize(HttpRequest request) {
+        request.setReadTimeout(2 * MILLIS_PER_MINUTE); // 2 minutes read timeout
+        final HttpUnsuccessfulResponseHandler backoffHandler =
+                new HttpBackOffUnsuccessfulResponseHandler(new ExponentialBackOff()).setSleeper(sleeper);
+        request.setInterceptor(wrappedCredential);
+        request.setUnsuccessfulResponseHandler(new HttpUnsuccessfulResponseHandler() {
+            public boolean handleResponse(
+                    final HttpRequest request, final HttpResponse response, final boolean supportsRetry)
+                    throws IOException {
+                if (wrappedCredential.handleResponse(request, response, supportsRetry)) {
+                    // If credential decides it can handle it, the return code or message indicated
+                    // something specific to authentication, and no backoff is desired.
+                    return true;
+                } else if (backoffHandler.handleResponse(request, response, supportsRetry)) {
+                    // Otherwise, we defer to the judgement of our internal backoff handler.
+                    LOG.info("Retrying " + request.getUrl().toString());
+                    return true;
+                } else {
+                    return false;
+                }
             }
-          }
         });
-    request.setIOExceptionHandler(
-        new HttpBackOffIOExceptionHandler(new ExponentialBackOff()).setSleeper(sleeper));
-  }
+        request.setIOExceptionHandler(new HttpBackOffIOExceptionHandler(new ExponentialBackOff()).setSleeper(sleeper));
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/client/StorageClient.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/client/StorageClient.java
@@ -28,100 +28,98 @@ import java.io.IOException;
  * @see <a href="https://cloud.google.com/storage/docs/json_api/v1/">Cloud Storage</a>
  */
 public class StorageClient {
-  private final Storage storage;
+    private final Storage storage;
 
-  /**
-   * Constructs a new {@link StorageClient} instance.
-   *
-   * @param storage The {@link Storage} instance this class will utilize for interacting with the
-   *     GCS API.
-   */
-  public StorageClient(Storage storage) {
-    this.storage = Preconditions.checkNotNull(storage);
-  }
+    /**
+     * Constructs a new {@link StorageClient} instance.
+     *
+     * @param storage The {@link Storage} instance this class will utilize for interacting with the
+     *     GCS API.
+     */
+    public StorageClient(Storage storage) {
+        this.storage = Preconditions.checkNotNull(storage);
+    }
 
-  /**
-   * Delete object matching pattern from Google Cloud Storage bucket of name bucket.
-   *
-   * @param bucket GCS bucket to delete from.
-   * @param pattern Pattern to match object name to delete from bucket.
-   * @throws IOException If there was an issue calling the GCS API.
-   */
-  public void deleteFromBucket(String bucket, String pattern) throws IOException {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(bucket));
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(pattern));
-    deleteFromBucketRequest(bucket, pattern).execute();
-  }
+    /**
+     * Delete object matching pattern from Google Cloud Storage bucket of name bucket.
+     *
+     * @param bucket GCS bucket to delete from.
+     * @param pattern Pattern to match object name to delete from bucket.
+     * @throws IOException If there was an issue calling the GCS API.
+     */
+    public void deleteFromBucket(String bucket, String pattern) throws IOException {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(bucket));
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(pattern));
+        deleteFromBucketRequest(bucket, pattern).execute();
+    }
 
-  /**
-   * Helper method to return the delete request.
-   *
-   * @param bucket GCS bucket to delete from.
-   * @param pattern Pattern to match object name to delete from bucket.
-   * @return Delete request.
-   * @throws IOException If there was an issue calling the GCS API.
-   */
-  public Storage.Objects.Delete deleteFromBucketRequest(String bucket, String pattern)
-      throws IOException {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(bucket));
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(pattern));
-    return storage.objects().delete(bucket, pattern);
-  }
+    /**
+     * Helper method to return the delete request.
+     *
+     * @param bucket GCS bucket to delete from.
+     * @param pattern Pattern to match object name to delete from bucket.
+     * @return Delete request.
+     * @throws IOException If there was an issue calling the GCS API.
+     */
+    public Storage.Objects.Delete deleteFromBucketRequest(String bucket, String pattern) throws IOException {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(bucket));
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(pattern));
+        return storage.objects().delete(bucket, pattern);
+    }
 
-  /**
-   * Uploads item with path pattern to Google Cloud Storage bucket of name bucket.
-   *
-   * @param pattern Pattern to match object name to upload to bucket.
-   * @param bucket Name of the bucket to upload to.
-   * @param content InputStreamContent of desired file to upload.
-   * @return The parsed HTTP response from the request.
-   * @throws IOException If there was an issue calling the GCS API.
-   */
-  public StorageObject uploadToBucket(String pattern, String bucket, InputStreamContent content)
-      throws IOException {
-    Preconditions.checkNotNull(content);
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(bucket));
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(pattern));
-    return uploadToBucketRequest(pattern, bucket, content).execute();
-  }
+    /**
+     * Uploads item with path pattern to Google Cloud Storage bucket of name bucket.
+     *
+     * @param pattern Pattern to match object name to upload to bucket.
+     * @param bucket Name of the bucket to upload to.
+     * @param content InputStreamContent of desired file to upload.
+     * @return The parsed HTTP response from the request.
+     * @throws IOException If there was an issue calling the GCS API.
+     */
+    public StorageObject uploadToBucket(String pattern, String bucket, InputStreamContent content) throws IOException {
+        Preconditions.checkNotNull(content);
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(bucket));
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(pattern));
+        return uploadToBucketRequest(pattern, bucket, content).execute();
+    }
 
-  /**
-   * Helper method to return the insert request.
-   *
-   * @param pattern Pattern to match object name to upload to bucket.
-   * @param bucket Name of the bucket to upload to.
-   * @param content InputStreamContent of desired file to upload.
-   * @return Insert request.
-   * @throws IOException If there was an issue calling the GCS API.
-   */
-  public Storage.Objects.Insert uploadToBucketRequest(
-      String pattern, String bucket, InputStreamContent content) throws IOException {
-    Preconditions.checkNotNull(content);
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(bucket));
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(pattern));
-    return storage.objects().insert(bucket, null, content).setName(pattern);
-  }
+    /**
+     * Helper method to return the insert request.
+     *
+     * @param pattern Pattern to match object name to upload to bucket.
+     * @param bucket Name of the bucket to upload to.
+     * @param content InputStreamContent of desired file to upload.
+     * @return Insert request.
+     * @throws IOException If there was an issue calling the GCS API.
+     */
+    public Storage.Objects.Insert uploadToBucketRequest(String pattern, String bucket, InputStreamContent content)
+            throws IOException {
+        Preconditions.checkNotNull(content);
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(bucket));
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(pattern));
+        return storage.objects().insert(bucket, null, content).setName(pattern);
+    }
 
-  /**
-   * Delete bucket from GCS with name bucket. Bucket must be empty.
-   *
-   * @param bucket Name of GCS bucket to delete.
-   * @throws IOException If there was an issue calling the GCS API.
-   */
-  public void deleteBucket(String bucket) throws IOException {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(bucket));
-    deleteBucketRequest(bucket).execute();
-  }
+    /**
+     * Delete bucket from GCS with name bucket. Bucket must be empty.
+     *
+     * @param bucket Name of GCS bucket to delete.
+     * @throws IOException If there was an issue calling the GCS API.
+     */
+    public void deleteBucket(String bucket) throws IOException {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(bucket));
+        deleteBucketRequest(bucket).execute();
+    }
 
-  /**
-   * Helper method to return the delete request.
-   *
-   * @param bucket Name of GCS bucket to delete.
-   * @return Delete request.
-   * @throws IOException If there was an issue calling the GCS API.
-   */
-  public Storage.Buckets.Delete deleteBucketRequest(String bucket) throws IOException {
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(bucket));
-    return storage.buckets().delete(bucket);
-  }
+    /**
+     * Helper method to return the delete request.
+     *
+     * @param bucket Name of GCS bucket to delete.
+     * @return Delete request.
+     * @throws IOException If there was an issue calling the GCS API.
+     */
+    public Storage.Buckets.Delete deleteBucketRequest(String bucket) throws IOException {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(bucket));
+        return storage.buckets().delete(bucket);
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/reports/AbstractGcsUploadReport.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/reports/AbstractGcsUploadReport.java
@@ -31,59 +31,59 @@ import java.util.Set;
  */
 public abstract class AbstractGcsUploadReport implements Action {
 
-  /**
-   * @see #getParent().
-   */
-  private Actionable parent;
+    /**
+     * @see #getParent().
+     */
+    private Actionable parent;
 
-  /**
-   * @param parent the parent object of this action.
-   * @see #getParent().
-   */
-  AbstractGcsUploadReport(Actionable parent) {
-    this.parent = checkNotNull(parent);
-  }
+    /**
+     * @param parent the parent object of this action.
+     * @see #getParent().
+     */
+    AbstractGcsUploadReport(Actionable parent) {
+        this.parent = checkNotNull(parent);
+    }
 
-  /** {@inheritDoc} */
-  @Override
-  public String getIconFileName() {
-    return "save.gif";
-  }
+    /** {@inheritDoc} */
+    @Override
+    public String getIconFileName() {
+        return "save.gif";
+    }
 
-  /** {@inheritDoc} */
-  @Override
-  public String getDisplayName() {
-    return Messages.AbstractGcsUploadReport_DisplayName();
-  }
+    /** {@inheritDoc} */
+    @Override
+    public String getDisplayName() {
+        return Messages.AbstractGcsUploadReport_DisplayName();
+    }
 
-  /** {@inheritDoc} */
-  @Override
-  public String getUrlName() {
-    /* stapler will match this URL name to our action page */
-    return "gcsObjects";
-  }
+    /** {@inheritDoc} */
+    @Override
+    public String getUrlName() {
+        /* stapler will match this URL name to our action page */
+        return "gcsObjects";
+    }
 
-  /**
-   * @return the parent object of this action. For a build action, this is the containing build. For
-   *     a project action, this is the containing project.
-   */
-  public Actionable getParent() {
-    return parent;
-  }
+    /**
+     * @return the parent object of this action. For a build action, this is the containing build. For
+     *     a project action, this is the containing project.
+     */
+    public Actionable getParent() {
+        return parent;
+    }
 
-  /**
-   * @return the build number of this report.
-   */
-  @Nullable
-  public abstract Integer getBuildNumber();
+    /**
+     * @return the build number of this report.
+     */
+    @Nullable
+    public abstract Integer getBuildNumber();
 
-  /**
-   * @return the uploaded objects (qualified with bucket name).
-   */
-  public abstract Set<String> getStorageObjects();
+    /**
+     * @return the uploaded objects (qualified with bucket name).
+     */
+    public abstract Set<String> getStorageObjects();
 
-  /**
-   * @return the buckets that were used as upload destinations.
-   */
-  public abstract Set<String> getBuckets();
+    /**
+     * @return the buckets that were used as upload destinations.
+     */
+    public abstract Set<String> getBuckets();
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/reports/BuildGcsUploadReport.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/reports/BuildGcsUploadReport.java
@@ -30,84 +30,84 @@ import java.util.Set;
  */
 public class BuildGcsUploadReport extends AbstractGcsUploadReport {
 
-  private final Set<String> buckets;
-  private final Set<String> files;
+    private final Set<String> buckets;
+    private final Set<String> files;
 
-  public BuildGcsUploadReport(Run<?, ?> run) {
-    super(run);
-    this.buckets = Sets.newHashSet();
-    this.files = Sets.newHashSet();
-  }
-
-  /**
-   * @param project a project to get {@link BuildGcsUploadReport} for.
-   * @return the {@link BuildGcsUploadReport} of the last build, as returned by {@link #of(Run)}, or
-   *     null of no build existed.
-   */
-  @Nullable
-  public static BuildGcsUploadReport of(AbstractProject<?, ?> project) {
-    // TODO(nghia) : Put more thoughts into whether we want getLastBuild()
-    // or getLastSuccessfulBuild() here.
-    //
-    // Displaying the last build has the advantage that logs for failed builds
-    // are also easily accessible through these links.
-    //
-    // On the other hand, last successful builds have a more complete set of
-    // links.
-    //
-    // May we only display the last build _if_ the project has uploads for
-    // failed build as well?
-    AbstractBuild<?, ?> lastBuild = project.getLastBuild();
-    return lastBuild == null ? null : BuildGcsUploadReport.of(lastBuild);
-  }
-
-  /**
-   * @param run the run to get {@link BuildGcsUploadReport} for.
-   * @return the existing {@link BuildGcsUploadReport} of a build. If none, create a new {@link
-   *     BuildGcsUploadReport} and return.
-   */
-  public static synchronized BuildGcsUploadReport of(Run<?, ?> run) {
-    BuildGcsUploadReport links = run.getAction(BuildGcsUploadReport.class);
-    if (links != null) {
-      return links;
+    public BuildGcsUploadReport(Run<?, ?> run) {
+        super(run);
+        this.buckets = Sets.newHashSet();
+        this.files = Sets.newHashSet();
     }
-    links = new BuildGcsUploadReport(run);
-    run.addAction(links);
-    return links;
-  }
 
-  /**
-   * @param bucketName the name of the destination bucket.
-   */
-  public void addBucket(String bucketName) {
-    buckets.add(bucketName);
-  }
-
-  /**
-   * @param relativePath the relative path (to the workspace) of the uploaded file.
-   * @param bucket the directory location in the cloud
-   */
-  public void addUpload(String relativePath, BucketPath bucket) {
-    synchronized (files) {
-      files.add(bucket.getPath() + "/" + relativePath);
+    /**
+     * @param project a project to get {@link BuildGcsUploadReport} for.
+     * @return the {@link BuildGcsUploadReport} of the last build, as returned by {@link #of(Run)}, or
+     *     null of no build existed.
+     */
+    @Nullable
+    public static BuildGcsUploadReport of(AbstractProject<?, ?> project) {
+        // TODO(nghia) : Put more thoughts into whether we want getLastBuild()
+        // or getLastSuccessfulBuild() here.
+        //
+        // Displaying the last build has the advantage that logs for failed builds
+        // are also easily accessible through these links.
+        //
+        // On the other hand, last successful builds have a more complete set of
+        // links.
+        //
+        // May we only display the last build _if_ the project has uploads for
+        // failed build as well?
+        AbstractBuild<?, ?> lastBuild = project.getLastBuild();
+        return lastBuild == null ? null : BuildGcsUploadReport.of(lastBuild);
     }
-  }
 
-  /** {@inheritDoc} */
-  @Override
-  public Set<String> getBuckets() {
-    return Collections.unmodifiableSet(buckets);
-  }
+    /**
+     * @param run the run to get {@link BuildGcsUploadReport} for.
+     * @return the existing {@link BuildGcsUploadReport} of a build. If none, create a new {@link
+     *     BuildGcsUploadReport} and return.
+     */
+    public static synchronized BuildGcsUploadReport of(Run<?, ?> run) {
+        BuildGcsUploadReport links = run.getAction(BuildGcsUploadReport.class);
+        if (links != null) {
+            return links;
+        }
+        links = new BuildGcsUploadReport(run);
+        run.addAction(links);
+        return links;
+    }
 
-  /** {@inheritDoc} */
-  @Override
-  public Set<String> getStorageObjects() {
-    return Collections.unmodifiableSet(files);
-  }
+    /**
+     * @param bucketName the name of the destination bucket.
+     */
+    public void addBucket(String bucketName) {
+        buckets.add(bucketName);
+    }
 
-  /** {@inheritDoc} */
-  @Override
-  public Integer getBuildNumber() {
-    return ((AbstractBuild<?, ?>) getParent()).getNumber();
-  }
+    /**
+     * @param relativePath the relative path (to the workspace) of the uploaded file.
+     * @param bucket the directory location in the cloud
+     */
+    public void addUpload(String relativePath, BucketPath bucket) {
+        synchronized (files) {
+            files.add(bucket.getPath() + "/" + relativePath);
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Set<String> getBuckets() {
+        return Collections.unmodifiableSet(buckets);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Set<String> getStorageObjects() {
+        return Collections.unmodifiableSet(files);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Integer getBuildNumber() {
+        return ((AbstractBuild<?, ?>) getParent()).getNumber();
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/reports/ProjectGcsUploadReport.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/reports/ProjectGcsUploadReport.java
@@ -33,35 +33,35 @@ import java.util.Set;
  */
 public class ProjectGcsUploadReport extends AbstractGcsUploadReport {
 
-  public ProjectGcsUploadReport(AbstractProject<?, ?> project) {
-    super(project);
-  }
+    public ProjectGcsUploadReport(AbstractProject<?, ?> project) {
+        super(project);
+    }
 
-  /**
-   * @return the project that this {@link ProjectGcsUploadReport} belongs to.
-   */
-  public AbstractProject<?, ?> getProject() {
-    return (AbstractProject<?, ?>) getParent();
-  }
+    /**
+     * @return the project that this {@link ProjectGcsUploadReport} belongs to.
+     */
+    public AbstractProject<?, ?> getProject() {
+        return (AbstractProject<?, ?>) getParent();
+    }
 
-  /** {@inheritDoc} */
-  @Override
-  public Set<String> getBuckets() {
-    BuildGcsUploadReport links = BuildGcsUploadReport.of(getProject());
-    return links == null ? ImmutableSet.<String>of() : links.getBuckets();
-  }
+    /** {@inheritDoc} */
+    @Override
+    public Set<String> getBuckets() {
+        BuildGcsUploadReport links = BuildGcsUploadReport.of(getProject());
+        return links == null ? ImmutableSet.<String>of() : links.getBuckets();
+    }
 
-  /** {@inheritDoc} */
-  @Override
-  public Set<String> getStorageObjects() {
-    BuildGcsUploadReport links = BuildGcsUploadReport.of(getProject());
-    return links == null ? ImmutableSet.<String>of() : links.getStorageObjects();
-  }
+    /** {@inheritDoc} */
+    @Override
+    public Set<String> getStorageObjects() {
+        BuildGcsUploadReport links = BuildGcsUploadReport.of(getProject());
+        return links == null ? ImmutableSet.<String>of() : links.getStorageObjects();
+    }
 
-  /** {@inheritDoc} */
-  @Override
-  public Integer getBuildNumber() {
-    BuildGcsUploadReport links = BuildGcsUploadReport.of(getProject());
-    return links == null ? null : links.getBuildNumber();
-  }
+    /** {@inheritDoc} */
+    @Override
+    public Integer getBuildNumber() {
+        BuildGcsUploadReport links = BuildGcsUploadReport.of(getProject());
+        return links == null ? null : links.getBuildNumber();
+    }
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/util/CredentialsUtil.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/util/CredentialsUtil.java
@@ -31,54 +31,50 @@ import java.security.GeneralSecurityException;
 
 /** Provides a library of utility functions for credentials-related work. */
 public class CredentialsUtil {
-  /**
-   * Get the Google Robot Credentials for the given credentialsId.
-   *
-   * @param itemGroup A handle to the Jenkins instance. Must be non-null.
-   * @param domainRequirements A list of domain requirements. Must be non-null.
-   * @param credentialsId The ID of the GoogleRobotCredentials to be retrieved from Jenkins and
-   *     utilized for authorization. Must be non-empty or non-null and exist in credentials store.
-   * @return Google Robot Credential for the given credentialsId.
-   * @throws hudson.AbortException If there was an issue retrieving the Google Robot Credentials.
-   */
-  public static GoogleRobotCredentials getRobotCredentials(
-      ItemGroup itemGroup,
-      ImmutableList<DomainRequirement> domainRequirements,
-      String credentialsId)
-      throws AbortException {
-    Preconditions.checkNotNull(itemGroup);
-    Preconditions.checkNotNull(domainRequirements);
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(credentialsId));
+    /**
+     * Get the Google Robot Credentials for the given credentialsId.
+     *
+     * @param itemGroup A handle to the Jenkins instance. Must be non-null.
+     * @param domainRequirements A list of domain requirements. Must be non-null.
+     * @param credentialsId The ID of the GoogleRobotCredentials to be retrieved from Jenkins and
+     *     utilized for authorization. Must be non-empty or non-null and exist in credentials store.
+     * @return Google Robot Credential for the given credentialsId.
+     * @throws hudson.AbortException If there was an issue retrieving the Google Robot Credentials.
+     */
+    public static GoogleRobotCredentials getRobotCredentials(
+            ItemGroup itemGroup, ImmutableList<DomainRequirement> domainRequirements, String credentialsId)
+            throws AbortException {
+        Preconditions.checkNotNull(itemGroup);
+        Preconditions.checkNotNull(domainRequirements);
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(credentialsId));
 
-    GoogleRobotCredentials robotCreds =
-        CredentialsMatchers.firstOrNull(
-            CredentialsProvider.lookupCredentials(
-                GoogleRobotCredentials.class, itemGroup, ACL.SYSTEM, domainRequirements),
-            CredentialsMatchers.withId(credentialsId));
+        GoogleRobotCredentials robotCreds = CredentialsMatchers.firstOrNull(
+                CredentialsProvider.lookupCredentials(
+                        GoogleRobotCredentials.class, itemGroup, ACL.SYSTEM, domainRequirements),
+                CredentialsMatchers.withId(credentialsId));
 
-    if (robotCreds == null) {
-      throw new AbortException(Messages.CredentialsUtil_FailedToRetrieveCredentials(credentialsId));
+        if (robotCreds == null) {
+            throw new AbortException(Messages.CredentialsUtil_FailedToRetrieveCredentials(credentialsId));
+        }
+
+        return robotCreds;
     }
 
-    return robotCreds;
-  }
+    /**
+     * Get the Credential from the Google robot credentials for GKE access.
+     *
+     * @param robotCreds Google Robot Credential for desired service account.
+     * @return Google Credential for the service account.
+     * @throws AbortException if there was an error initializing HTTP transport.
+     */
+    public static Credential getGoogleCredential(GoogleRobotCredentials robotCreds) throws AbortException {
+        Credential credential;
+        try {
+            credential = robotCreds.getGoogleCredential(new StorageScopeRequirement());
+        } catch (GeneralSecurityException gse) {
+            throw new AbortException(Messages.CredentialsUtil_FailedToInitializeHTTPTransport(gse));
+        }
 
-  /**
-   * Get the Credential from the Google robot credentials for GKE access.
-   *
-   * @param robotCreds Google Robot Credential for desired service account.
-   * @return Google Credential for the service account.
-   * @throws AbortException if there was an error initializing HTTP transport.
-   */
-  public static Credential getGoogleCredential(GoogleRobotCredentials robotCreds)
-      throws AbortException {
-    Credential credential;
-    try {
-      credential = robotCreds.getGoogleCredential(new StorageScopeRequirement());
-    } catch (GeneralSecurityException gse) {
-      throw new AbortException(Messages.CredentialsUtil_FailedToInitializeHTTPTransport(gse));
+        return credential;
     }
-
-    return credential;
-  }
 }

--- a/src/main/java/com/google/jenkins/plugins/storage/util/StorageUtil.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/util/StorageUtil.java
@@ -30,74 +30,74 @@ import java.util.LinkedList;
 /** A class to contain common utility operations */
 public class StorageUtil {
 
-  /**
-   * Compute the relative path of the given file inclusion, relative to the given workspace. If the
-   * path is absolute, it returns the root-relative path instead.
-   *
-   * @param include The file whose relative path we are computing.
-   * @param workspace The workspace containing the included file.
-   * @return The unix-style relative path of file.
-   * @throws UploadException when the input is malformed
-   */
-  public static String getRelative(FilePath include, FilePath workspace) throws UploadException {
-    LinkedList<String> segments = new LinkedList<String>();
-    while (!include.equals(workspace)) {
-      segments.push(include.getName());
-      include = include.getParent();
-      if (Strings.isNullOrEmpty(include.getName())) {
-        // When we reach "/" we're done either way.
-        break;
-      }
+    /**
+     * Compute the relative path of the given file inclusion, relative to the given workspace. If the
+     * path is absolute, it returns the root-relative path instead.
+     *
+     * @param include The file whose relative path we are computing.
+     * @param workspace The workspace containing the included file.
+     * @return The unix-style relative path of file.
+     * @throws UploadException when the input is malformed
+     */
+    public static String getRelative(FilePath include, FilePath workspace) throws UploadException {
+        LinkedList<String> segments = new LinkedList<String>();
+        while (!include.equals(workspace)) {
+            segments.push(include.getName());
+            include = include.getParent();
+            if (Strings.isNullOrEmpty(include.getName())) {
+                // When we reach "/" we're done either way.
+                break;
+            }
+        }
+        return String.join("/", segments);
     }
-    return String.join("/", segments);
-  }
 
-  /**
-   * If a path prefix to strip has been specified, and the input string starts with that prefix,
-   * returns the portion of the input after that prefix. Otherwise, returns the unmodified input.
-   *
-   * @param filename Input string to strip.
-   * @param pathPrefix Name of the path prefix to strip on.
-   * @return Remaining portion of the input after prefix is stripped.
-   */
-  public static String getStrippedFilename(String filename, String pathPrefix) {
-    if (pathPrefix != null && filename != null && filename.startsWith(pathPrefix)) {
-      return filename.substring(pathPrefix.length());
+    /**
+     * If a path prefix to strip has been specified, and the input string starts with that prefix,
+     * returns the portion of the input after that prefix. Otherwise, returns the unmodified input.
+     *
+     * @param filename Input string to strip.
+     * @param pathPrefix Name of the path prefix to strip on.
+     * @return Remaining portion of the input after prefix is stripped.
+     */
+    public static String getStrippedFilename(String filename, String pathPrefix) {
+        if (pathPrefix != null && filename != null && filename.startsWith(pathPrefix)) {
+            return filename.substring(pathPrefix.length());
+        }
+        return filename;
     }
-    return filename;
-  }
 
-  /**
-   * Perform variable expansion for non-pipeline steps.
-   *
-   * @param name The name, potentially including with variables
-   * @param run The current run, used to determine pipeline status and to get environment.
-   * @param listener Task listener, used to get environment
-   * @return The updated name, with variables resolved
-   * @throws InterruptedException If getting the environment of the run throws an
-   *     InterruptedException.
-   * @throws IOException If getting the environment of the run throws an IOException.
-   */
-  public static String replaceMacro(String name, Run<?, ?> run, TaskListener listener)
-      throws InterruptedException, IOException {
-    if (run instanceof AbstractBuild) {
-      name = Util.replaceMacro(name, run.getEnvironment(listener));
+    /**
+     * Perform variable expansion for non-pipeline steps.
+     *
+     * @param name The name, potentially including with variables
+     * @param run The current run, used to determine pipeline status and to get environment.
+     * @param listener Task listener, used to get environment
+     * @return The updated name, with variables resolved
+     * @throws InterruptedException If getting the environment of the run throws an
+     *     InterruptedException.
+     * @throws IOException If getting the environment of the run throws an IOException.
+     */
+    public static String replaceMacro(String name, Run<?, ?> run, TaskListener listener)
+            throws InterruptedException, IOException {
+        if (run instanceof AbstractBuild) {
+            name = Util.replaceMacro(name, run.getEnvironment(listener));
+        }
+        return name;
     }
-    return name;
-  }
 
-  /**
-   * Look up credentials by name.
-   *
-   * @param credentials The name of the credentials to look up.
-   * @return The corresponding {@link GoogleRobotCredentials}.
-   * @throws AbortException If credentials not found.
-   */
-  public static GoogleRobotCredentials lookupCredentials(String credentials) throws AbortException {
-    GoogleRobotCredentials result = GoogleRobotCredentials.getById(credentials);
-    if (result == null) {
-      throw new AbortException("Unknown credentials: " + credentials);
+    /**
+     * Look up credentials by name.
+     *
+     * @param credentials The name of the credentials to look up.
+     * @return The corresponding {@link GoogleRobotCredentials}.
+     * @throws AbortException If credentials not found.
+     */
+    public static GoogleRobotCredentials lookupCredentials(String credentials) throws AbortException {
+        GoogleRobotCredentials result = GoogleRobotCredentials.getById(credentials);
+        if (result == null) {
+            throw new AbortException("Unknown credentials: " + credentials);
+        }
+        return result;
     }
-    return result;
-  }
 }

--- a/src/test/java/com/google/api/client/http/StubHttpResponseException.java
+++ b/src/test/java/com/google/api/client/http/StubHttpResponseException.java
@@ -18,11 +18,11 @@ package com.google.api.client.http;
 /** Liberal use of the 'final' keyword makes mocking HttpResponseException impossible. */
 public class StubHttpResponseException extends HttpResponseException {
 
-  /**
-   * @param statusCode the HTTP status code
-   * @param statusMessage the message to be included in the exception
-   */
-  public StubHttpResponseException(int statusCode, String statusMessage) {
-    super(new Builder(statusCode, statusMessage, new HttpHeaders()));
-  }
+    /**
+     * @param statusCode the HTTP status code
+     * @param statusMessage the message to be included in the exception
+     */
+    public StubHttpResponseException(int statusCode, String statusMessage) {
+        super(new Builder(statusCode, statusMessage, new HttpHeaders()));
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/storage/ClassicUploadStepTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/ClassicUploadStepTest.java
@@ -43,120 +43,115 @@ import org.mockito.MockitoAnnotations;
 /** Tests for {@link ClassicUpload}. */
 public class ClassicUploadStepTest {
 
-  @Rule public JenkinsRule jenkins = new JenkinsRule();
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
 
-  @Mock private GoogleRobotCredentials credentials;
+    @Mock
+    private GoogleRobotCredentials credentials;
 
-  private GoogleCredential credential;
-  @Mock private AbstractGoogleRobotCredentialsDescriptor descriptor;
+    private GoogleCredential credential;
 
-  private final MockExecutor executor = new MockExecutor();
+    @Mock
+    private AbstractGoogleRobotCredentialsDescriptor descriptor;
 
-  private NotFoundException notFoundException = new NotFoundException();
+    private final MockExecutor executor = new MockExecutor();
 
-  @Before
-  public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
+    private NotFoundException notFoundException = new NotFoundException();
 
-    when(descriptor.getDisplayName()).thenReturn("Credentials Name");
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
 
-    when(credentials.getId()).thenReturn(CREDENTIALS_ID);
-    when(credentials.getProjectId()).thenReturn(PROJECT_ID);
-    when(credentials.getDescriptor()).thenReturn(descriptor);
+        when(descriptor.getDisplayName()).thenReturn("Credentials Name");
 
-    if (jenkins.jenkins != null) {
-      SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
+        when(credentials.getId()).thenReturn(CREDENTIALS_ID);
+        when(credentials.getProjectId()).thenReturn(PROJECT_ID);
+        when(credentials.getDescriptor()).thenReturn(descriptor);
+
+        if (jenkins.jenkins != null) {
+            SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
+        }
+
+        credential = new GoogleCredential();
+        when(credentials.getGoogleCredential(isA(GoogleOAuth2ScopeRequirement.class)))
+                .thenReturn(credential);
+        when(credentials.forRemote(isA(GoogleOAuth2ScopeRequirement.class))).thenReturn(credentials);
     }
 
-    credential = new GoogleCredential();
-    when(credentials.getGoogleCredential(isA(GoogleOAuth2ScopeRequirement.class)))
-        .thenReturn(credential);
-    when(credentials.forRemote(isA(GoogleOAuth2ScopeRequirement.class))).thenReturn(credentials);
-  }
-
-  private void ConfigurationRoundTripTest(ClassicUploadStep s) throws Exception {
-    ClassicUploadStep after = jenkins.configRoundtrip(s);
-    jenkins.assertEqualBeans(s, after, "bucket,pattern,pathPrefix,credentialsId");
-  }
-
-  @Test
-  public void testRoundtrip() throws Exception {
-    assumeFalse(SystemUtils.IS_OS_WINDOWS);
-    ClassicUploadStep step = new ClassicUploadStep(CREDENTIALS_ID, "bucket", "pattern");
-    ConfigurationRoundTripTest(step);
-
-    step.setPathPrefix("prefix");
-    ConfigurationRoundTripTest(step);
-
-    step.setSharedPublicly(true);
-    ConfigurationRoundTripTest(step);
-
-    step.setShowInline(true);
-    ConfigurationRoundTripTest(step);
-  }
-
-  @Test
-  public void testBuild() throws Exception {
-    ClassicUploadStep step =
-        new ClassicUploadStep(
-            CREDENTIALS_ID, BUCKET_URI, new MockUploadModule(executor), "*.$BUILD_ID.txt");
-    FreeStyleProject project = jenkins.createFreeStyleProject("testBuild");
-
-    executor.throwWhen(Storage.Buckets.Get.class, notFoundException);
-    executor.passThruWhen(
-        Storage.Buckets.Insert.class, MockUploadModule.checkBucketName(BUCKET_NAME));
-    executor.passThruWhen(
-        Storage.Objects.Insert.class, MockUploadModule.checkObjectName("abc.1.txt"));
-
-    project.getBuildersList().add(step);
-
-    FreeStyleBuild build = project.scheduleBuild2(0).get();
-
-    // Put three different files in the workspace. Only one should match if
-    // the expansion is done correctly.
-    build.getWorkspace().child("abc.7.txt").write("hello", "UTF-8");
-    build.getWorkspace().child("abc.1.txt").write("hello", "UTF-8");
-    build.getWorkspace().child("abc.$BUILD_ID.txt").write("hello", "UTF-8");
-    step.perform(
-        build,
-        build.getWorkspace(),
-        build.getWorkspace().createLauncher(TaskListener.NULL),
-        TaskListener.NULL);
-  }
-
-  @Test
-  public void testInvalidCredentials() throws Exception {
-    ClassicUploadStep step =
-        new ClassicUploadStep(
-            "bad-credentials", BUCKET_URI, new MockUploadModule(executor), "*.$BUILD_ID.txt");
-    FreeStyleProject project = jenkins.createFreeStyleProject("testBuild");
-
-    executor.throwWhen(Storage.Buckets.Get.class, notFoundException);
-    executor.passThruWhen(
-        Storage.Buckets.Insert.class, MockUploadModule.checkBucketName(BUCKET_NAME));
-    executor.passThruWhen(
-        Storage.Objects.Insert.class, MockUploadModule.checkObjectName("abc.1.txt"));
-
-    project.getBuildersList().add(step);
-    FreeStyleBuild build = project.scheduleBuild2(0).get();
-
-    try {
-      step.perform(
-          build,
-          build.getWorkspace(),
-          build.getWorkspace().createLauncher(TaskListener.NULL),
-          TaskListener.NULL);
-    } catch (AbortException e) {
-      assertTrue(e.getMessage().contains("bad-credentials"));
-      return;
+    private void ConfigurationRoundTripTest(ClassicUploadStep s) throws Exception {
+        ClassicUploadStep after = jenkins.configRoundtrip(s);
+        jenkins.assertEqualBeans(s, after, "bucket,pattern,pathPrefix,credentialsId");
     }
-    // Expected exception to happen.
-    assertTrue(false);
-  }
 
-  private static final String PROJECT_ID = "foo.com:project-build";
-  private static final String CREDENTIALS_ID = "creds";
+    @Test
+    public void testRoundtrip() throws Exception {
+        assumeFalse(SystemUtils.IS_OS_WINDOWS);
+        ClassicUploadStep step = new ClassicUploadStep(CREDENTIALS_ID, "bucket", "pattern");
+        ConfigurationRoundTripTest(step);
 
-  private static final String BUCKET_NAME = "test-bucket-42";
-  private static final String BUCKET_URI = "gs://" + BUCKET_NAME;
+        step.setPathPrefix("prefix");
+        ConfigurationRoundTripTest(step);
+
+        step.setSharedPublicly(true);
+        ConfigurationRoundTripTest(step);
+
+        step.setShowInline(true);
+        ConfigurationRoundTripTest(step);
+    }
+
+    @Test
+    public void testBuild() throws Exception {
+        ClassicUploadStep step =
+                new ClassicUploadStep(CREDENTIALS_ID, BUCKET_URI, new MockUploadModule(executor), "*.$BUILD_ID.txt");
+        FreeStyleProject project = jenkins.createFreeStyleProject("testBuild");
+
+        executor.throwWhen(Storage.Buckets.Get.class, notFoundException);
+        executor.passThruWhen(Storage.Buckets.Insert.class, MockUploadModule.checkBucketName(BUCKET_NAME));
+        executor.passThruWhen(Storage.Objects.Insert.class, MockUploadModule.checkObjectName("abc.1.txt"));
+
+        project.getBuildersList().add(step);
+
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+
+        // Put three different files in the workspace. Only one should match if
+        // the expansion is done correctly.
+        build.getWorkspace().child("abc.7.txt").write("hello", "UTF-8");
+        build.getWorkspace().child("abc.1.txt").write("hello", "UTF-8");
+        build.getWorkspace().child("abc.$BUILD_ID.txt").write("hello", "UTF-8");
+        step.perform(
+                build, build.getWorkspace(), build.getWorkspace().createLauncher(TaskListener.NULL), TaskListener.NULL);
+    }
+
+    @Test
+    public void testInvalidCredentials() throws Exception {
+        ClassicUploadStep step =
+                new ClassicUploadStep("bad-credentials", BUCKET_URI, new MockUploadModule(executor), "*.$BUILD_ID.txt");
+        FreeStyleProject project = jenkins.createFreeStyleProject("testBuild");
+
+        executor.throwWhen(Storage.Buckets.Get.class, notFoundException);
+        executor.passThruWhen(Storage.Buckets.Insert.class, MockUploadModule.checkBucketName(BUCKET_NAME));
+        executor.passThruWhen(Storage.Objects.Insert.class, MockUploadModule.checkObjectName("abc.1.txt"));
+
+        project.getBuildersList().add(step);
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+
+        try {
+            step.perform(
+                    build,
+                    build.getWorkspace(),
+                    build.getWorkspace().createLauncher(TaskListener.NULL),
+                    TaskListener.NULL);
+        } catch (AbortException e) {
+            assertTrue(e.getMessage().contains("bad-credentials"));
+            return;
+        }
+        // Expected exception to happen.
+        assertTrue(false);
+    }
+
+    private static final String PROJECT_ID = "foo.com:project-build";
+    private static final String CREDENTIALS_ID = "creds";
+
+    private static final String BUCKET_NAME = "test-bucket-42";
+    private static final String BUCKET_URI = "gs://" + BUCKET_NAME;
 }

--- a/src/test/java/com/google/jenkins/plugins/storage/DownloadStepTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/DownloadStepTest.java
@@ -54,271 +54,256 @@ import org.mockito.MockitoAnnotations;
 /** Tests for {@link AbstractUpload}. */
 public class DownloadStepTest {
 
-  @Rule public JenkinsRule jenkins = new JenkinsRule();
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
 
-  @Rule public TemporaryFolder tempDir = new TemporaryFolder();
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
 
-  @Mock private GoogleRobotCredentials credentials;
-  private GoogleCredential credential;
+    @Mock
+    private GoogleRobotCredentials credentials;
 
-  private final MockExecutor executor = new MockExecutor();
+    private GoogleCredential credential;
 
-  @Mock private AbstractGoogleRobotCredentialsDescriptor descriptor;
+    private final MockExecutor executor = new MockExecutor();
 
-  @Before
-  public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
+    @Mock
+    private AbstractGoogleRobotCredentialsDescriptor descriptor;
 
-    when(descriptor.getDisplayName()).thenReturn("Credentials Name");
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
 
-    when(credentials.getId()).thenReturn(CREDENTIALS_ID);
-    when(credentials.getProjectId()).thenReturn(PROJECT_ID);
-    when(credentials.getDescriptor()).thenReturn(descriptor);
+        when(descriptor.getDisplayName()).thenReturn("Credentials Name");
 
-    if (jenkins.jenkins != null) {
-      SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
+        when(credentials.getId()).thenReturn(CREDENTIALS_ID);
+        when(credentials.getProjectId()).thenReturn(PROJECT_ID);
+        when(credentials.getDescriptor()).thenReturn(descriptor);
+
+        if (jenkins.jenkins != null) {
+            SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
+        }
+
+        credential = new GoogleCredential();
+        when(credentials.getGoogleCredential(isA(GoogleOAuth2ScopeRequirement.class)))
+                .thenReturn(credential);
+
+        // Return ourselves as remotable
+        when(credentials.forRemote(isA(GoogleOAuth2ScopeRequirement.class))).thenReturn(credentials);
     }
 
-    credential = new GoogleCredential();
-    when(credentials.getGoogleCredential(isA(GoogleOAuth2ScopeRequirement.class)))
-        .thenReturn(credential);
-
-    // Return ourselves as remotable
-    when(credentials.forRemote(isA(GoogleOAuth2ScopeRequirement.class))).thenReturn(credentials);
-  }
-
-  private void ConfigurationRoundTripTest(DownloadStep s) throws Exception {
-    DownloadStep after = jenkins.configRoundtrip(s);
-    jenkins.assertEqualBeans(s, after, "bucketUri,localDirectory,pathPrefix,credentialsId");
-  }
-
-  @Test
-  public void testRoundtrip() throws Exception {
-    DownloadStep step =
-        new DownloadStep(CREDENTIALS_ID, "bucket", "Dir", new MockUploadModule(executor));
-    ConfigurationRoundTripTest(step);
-
-    step.setPathPrefix("prefix");
-    ConfigurationRoundTripTest(step);
-  }
-
-  @Test
-  public void testBuild() throws Exception {
-    MockUploadModule module = new MockUploadModule(executor);
-    DownloadStep step =
-        new DownloadStep(CREDENTIALS_ID, "gs://bucket/path/to/object.txt", "", module);
-    FreeStyleProject project = jenkins.createFreeStyleProject("testBuild");
-
-    // Set up mock to retrieve the object
-    StorageObject objToGet = new StorageObject();
-    objToGet.setBucket("bucket");
-    objToGet.setName("path/to/obj.txt");
-    executor.when(
-        Storage.Objects.Get.class, objToGet, MockUploadModule.checkGetObject("path/to/object.txt"));
-
-    module.addNextMedia(IOUtils.toInputStream("test", "UTF-8"));
-
-    project.getBuildersList().add(step);
-    FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
-
-    FilePath result = build.getWorkspace().withSuffix("/path/to/obj.txt");
-    assertTrue(result.exists());
-    assertEquals("test", result.readToString());
-  }
-
-  @Test
-  public void testBuildPrefix() throws Exception {
-    MockUploadModule module = new MockUploadModule(executor);
-    DownloadStep step =
-        new DownloadStep(CREDENTIALS_ID, "gs://bucket/path/to/object.txt", "subPath", module);
-    step.setPathPrefix("path/to/");
-    FreeStyleProject project = jenkins.createFreeStyleProject("testBuild");
-
-    // Set up mock to retrieve the object
-    StorageObject objToGet = new StorageObject();
-    objToGet.setBucket("bucket");
-    objToGet.setName("path/to/obj.txt");
-    executor.when(
-        Storage.Objects.Get.class, objToGet, MockUploadModule.checkGetObject("path/to/object.txt"));
-
-    module.addNextMedia(IOUtils.toInputStream("test", "UTF-8"));
-
-    project.getBuildersList().add(step);
-    FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
-
-    FilePath result = build.getWorkspace().withSuffix("/subPath/obj.txt");
-    assertTrue(result.exists());
-    assertEquals("test", result.readToString());
-  }
-
-  @Test
-  public void testBuildMoreComplex() throws Exception {
-    MockUploadModule module = new MockUploadModule(executor);
-    DownloadStep step =
-        new DownloadStep(
-            CREDENTIALS_ID,
-            "gs://bucket/download/$BUILD_ID/path/$BUILD_ID/test_$BUILD_ID.txt",
-            "output",
-            module);
-    step.setPathPrefix("download/$BUILD_ID/");
-    FreeStyleProject project = jenkins.createFreeStyleProject("testBuild");
-
-    // Set up mock to retrieve the object
-    StorageObject objToGet = new StorageObject();
-    objToGet.setBucket("bucket");
-    objToGet.setName("download/1/path/1/test_1.txt");
-    executor.when(
-        Storage.Objects.Get.class,
-        objToGet,
-        MockUploadModule.checkGetObject("download/1/path/1/test_1.txt"));
-
-    module.addNextMedia(IOUtils.toInputStream("contents 1", "UTF-8"));
-
-    project.getBuildersList().add(step);
-    FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
-
-    FilePath result = build.getWorkspace().withSuffix("/output/path/1/test_1.txt");
-    assertTrue(result.exists());
-    assertEquals("contents 1", result.readToString());
-  }
-
-  private void checkSplitException(String s) {
-    try {
-      DownloadStep.split(s);
-    } catch (AbortException e) {
-      assertTrue(e.getMessage().contains("Multiple asterisks"));
-      return;
+    private void ConfigurationRoundTripTest(DownloadStep s) throws Exception {
+        DownloadStep after = jenkins.configRoundtrip(s);
+        jenkins.assertEqualBeans(s, after, "bucketUri,localDirectory,pathPrefix,credentialsId");
     }
-    fail("Expected split to fail on input " + s);
-  }
 
-  @Test
-  @WithoutJenkins
-  public void testSplit() throws Exception {
-    assertArrayEquals(DownloadStep.split("a"), new String[] {"a"});
-    assertArrayEquals(
-        DownloadStep.split("asdjfkl2358/9/8024@#$@%^$#^#"),
-        new String[] {"asdjfkl2358/9/8024@#$@%^$#^#"});
+    @Test
+    public void testRoundtrip() throws Exception {
+        DownloadStep step = new DownloadStep(CREDENTIALS_ID, "bucket", "Dir", new MockUploadModule(executor));
+        ConfigurationRoundTripTest(step);
 
-    assertArrayEquals(DownloadStep.split("a*"), new String[] {"a", ""});
-    assertArrayEquals(DownloadStep.split("*"), new String[] {"", ""});
+        step.setPathPrefix("prefix");
+        ConfigurationRoundTripTest(step);
+    }
 
-    assertArrayEquals(DownloadStep.split("pre-*-post"), new String[] {"pre-", "-post"});
+    @Test
+    public void testBuild() throws Exception {
+        MockUploadModule module = new MockUploadModule(executor);
+        DownloadStep step = new DownloadStep(CREDENTIALS_ID, "gs://bucket/path/to/object.txt", "", module);
+        FreeStyleProject project = jenkins.createFreeStyleProject("testBuild");
 
-    // Not yet supported
-    checkSplitException("**");
-    checkSplitException("a**");
-    checkSplitException("a*b*c");
-    checkSplitException("a/*b/*c");
-  }
-
-  /**
-   * Create the Objects object that would have been returned from the Cloud.
-   *
-   * @param prefix the requested object prefix
-   * @param names a list of object names that are available
-   */
-  private Objects createObjects(String prefix, List<String> names) {
-    Objects o = new Objects();
-    List<StorageObject> items = new ArrayList<StorageObject>();
-    Set<String> prefixes = new HashSet<String>();
-    for (String s : names) {
-      if (!s.startsWith(prefix)) {
-        continue;
-      }
-
-      String subdirectory[] = s.substring(prefix.length()).split("/");
-      if (subdirectory.length > 1) {
-        // This object is nested deeper. Add a subdirectory
-        prefixes.add(prefix + subdirectory[0]);
-      } else {
-        // Add the object
+        // Set up mock to retrieve the object
         StorageObject objToGet = new StorageObject();
         objToGet.setBucket("bucket");
-        objToGet.setName(s);
-        items.add(objToGet);
-      }
-    }
-    o.setItems(items);
-    o.setPrefixes(new ArrayList<String>(prefixes));
-    return o;
-  }
+        objToGet.setName("path/to/obj.txt");
+        executor.when(Storage.Objects.Get.class, objToGet, MockUploadModule.checkGetObject("path/to/object.txt"));
 
-  public void tryWildcards(String uriPostfix, String[] matches, String[] notMatches)
-      throws Exception {
-    MockUploadModule module = new MockUploadModule(executor);
-    DownloadStep step = new DownloadStep(CREDENTIALS_ID, "gs://bucket/" + uriPostfix, ".", module);
+        module.addNextMedia(IOUtils.toInputStream("test", "UTF-8"));
 
-    FreeStyleProject project = jenkins.createFreeStyleProject("testBuild");
+        project.getBuildersList().add(step);
+        FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
 
-    final List<String> objectNames = new ArrayList<String>();
-    objectNames.addAll(Arrays.asList(matches));
-    objectNames.addAll(Arrays.asList(notMatches));
-
-    int index = uriPostfix.indexOf('*');
-
-    final String prefix;
-    if (index >= 0) {
-      prefix = uriPostfix.substring(0, index);
-    } else {
-      prefix = uriPostfix;
+        FilePath result = build.getWorkspace().withSuffix("/path/to/obj.txt");
+        assertTrue(result.exists());
+        assertEquals("test", result.readToString());
     }
 
-    Objects objects = createObjects(prefix, objectNames);
+    @Test
+    public void testBuildPrefix() throws Exception {
+        MockUploadModule module = new MockUploadModule(executor);
+        DownloadStep step = new DownloadStep(CREDENTIALS_ID, "gs://bucket/path/to/object.txt", "subPath", module);
+        step.setPathPrefix("path/to/");
+        FreeStyleProject project = jenkins.createFreeStyleProject("testBuild");
 
-    for (String s : objectNames) {
-      // ensure module has enough streams. Since the order in which they
-      // will be queries is undefined, we will not attempt to verify
-      // which one belongs to which.
-      module.addNextMedia(IOUtils.toInputStream("contents 1", "UTF-8"));
+        // Set up mock to retrieve the object
+        StorageObject objToGet = new StorageObject();
+        objToGet.setBucket("bucket");
+        objToGet.setName("path/to/obj.txt");
+        executor.when(Storage.Objects.Get.class, objToGet, MockUploadModule.checkGetObject("path/to/object.txt"));
+
+        module.addNextMedia(IOUtils.toInputStream("test", "UTF-8"));
+
+        project.getBuildersList().add(step);
+        FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
+
+        FilePath result = build.getWorkspace().withSuffix("/subPath/obj.txt");
+        assertTrue(result.exists());
+        assertEquals("test", result.readToString());
     }
 
-    // Stub out the response from the Cloud
-    executor.when(Storage.Objects.List.class, objects);
+    @Test
+    public void testBuildMoreComplex() throws Exception {
+        MockUploadModule module = new MockUploadModule(executor);
+        DownloadStep step = new DownloadStep(
+                CREDENTIALS_ID, "gs://bucket/download/$BUILD_ID/path/$BUILD_ID/test_$BUILD_ID.txt", "output", module);
+        step.setPathPrefix("download/$BUILD_ID/");
+        FreeStyleProject project = jenkins.createFreeStyleProject("testBuild");
 
-    project.getBuildersList().add(step);
-    FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
+        // Set up mock to retrieve the object
+        StorageObject objToGet = new StorageObject();
+        objToGet.setBucket("bucket");
+        objToGet.setName("download/1/path/1/test_1.txt");
+        executor.when(
+                Storage.Objects.Get.class, objToGet, MockUploadModule.checkGetObject("download/1/path/1/test_1.txt"));
 
-    for (String s : matches) {
-      FilePath result = build.getWorkspace().withSuffix("/" + s);
-      assertTrue(result.exists());
-      assertEquals("contents 1", result.readToString());
+        module.addNextMedia(IOUtils.toInputStream("contents 1", "UTF-8"));
+
+        project.getBuildersList().add(step);
+        FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
+
+        FilePath result = build.getWorkspace().withSuffix("/output/path/1/test_1.txt");
+        assertTrue(result.exists());
+        assertEquals("contents 1", result.readToString());
     }
-    for (String s : notMatches) {
-      FilePath result = build.getWorkspace().withSuffix("/" + s);
-      assertFalse("File exists but shouldn't:" + result, result.exists());
+
+    private void checkSplitException(String s) {
+        try {
+            DownloadStep.split(s);
+        } catch (AbortException e) {
+            assertTrue(e.getMessage().contains("Multiple asterisks"));
+            return;
+        }
+        fail("Expected split to fail on input " + s);
     }
-  }
 
-  @Test
-  public void testBuildWildcards() throws Exception {
-    tryWildcards(
-        "download/log_*.txt",
-        new String[] {
-          "download/log_1.txt",
-          "download/log_1_.txt",
-          "download/log_.txt",
-          "download/log_ajkl23-d.txt"
-        },
-        new String[] {
-          "downloa/log_1.txt",
-          "download/log.txt",
-          "download/log_",
-          "download/log_1/a.txt",
-          "download/log_1"
-        });
-  }
+    @Test
+    @WithoutJenkins
+    public void testSplit() throws Exception {
+        assertArrayEquals(DownloadStep.split("a"), new String[] {"a"});
+        assertArrayEquals(
+                DownloadStep.split("asdjfkl2358/9/8024@#$@%^$#^#"), new String[] {"asdjfkl2358/9/8024@#$@%^$#^#"});
 
-  @Test
-  public void testBuildWildcardsOnly() throws Exception {
-    tryWildcards("*", new String[] {"a", "b.txt", "l_a_b_d_f"}, new String[] {"a/b.txt", "/b"});
-  }
+        assertArrayEquals(DownloadStep.split("a*"), new String[] {"a", ""});
+        assertArrayEquals(DownloadStep.split("*"), new String[] {"", ""});
 
-  @Test
-  public void testBuildWildcardEnd() throws Exception {
-    tryWildcards("a/*", new String[] {"a/a.txt", "a/b.txt", "a/log"}, new String[] {"a/b/c.txt"});
-  }
+        assertArrayEquals(DownloadStep.split("pre-*-post"), new String[] {"pre-", "-post"});
 
-  private static final String PROJECT_ID = "foo.com:bar-baz";
-  private static final String CREDENTIALS_ID = "bazinga";
+        // Not yet supported
+        checkSplitException("**");
+        checkSplitException("a**");
+        checkSplitException("a*b*c");
+        checkSplitException("a/*b/*c");
+    }
+
+    /**
+     * Create the Objects object that would have been returned from the Cloud.
+     *
+     * @param prefix the requested object prefix
+     * @param names a list of object names that are available
+     */
+    private Objects createObjects(String prefix, List<String> names) {
+        Objects o = new Objects();
+        List<StorageObject> items = new ArrayList<StorageObject>();
+        Set<String> prefixes = new HashSet<String>();
+        for (String s : names) {
+            if (!s.startsWith(prefix)) {
+                continue;
+            }
+
+            String subdirectory[] = s.substring(prefix.length()).split("/");
+            if (subdirectory.length > 1) {
+                // This object is nested deeper. Add a subdirectory
+                prefixes.add(prefix + subdirectory[0]);
+            } else {
+                // Add the object
+                StorageObject objToGet = new StorageObject();
+                objToGet.setBucket("bucket");
+                objToGet.setName(s);
+                items.add(objToGet);
+            }
+        }
+        o.setItems(items);
+        o.setPrefixes(new ArrayList<String>(prefixes));
+        return o;
+    }
+
+    public void tryWildcards(String uriPostfix, String[] matches, String[] notMatches) throws Exception {
+        MockUploadModule module = new MockUploadModule(executor);
+        DownloadStep step = new DownloadStep(CREDENTIALS_ID, "gs://bucket/" + uriPostfix, ".", module);
+
+        FreeStyleProject project = jenkins.createFreeStyleProject("testBuild");
+
+        final List<String> objectNames = new ArrayList<String>();
+        objectNames.addAll(Arrays.asList(matches));
+        objectNames.addAll(Arrays.asList(notMatches));
+
+        int index = uriPostfix.indexOf('*');
+
+        final String prefix;
+        if (index >= 0) {
+            prefix = uriPostfix.substring(0, index);
+        } else {
+            prefix = uriPostfix;
+        }
+
+        Objects objects = createObjects(prefix, objectNames);
+
+        for (String s : objectNames) {
+            // ensure module has enough streams. Since the order in which they
+            // will be queries is undefined, we will not attempt to verify
+            // which one belongs to which.
+            module.addNextMedia(IOUtils.toInputStream("contents 1", "UTF-8"));
+        }
+
+        // Stub out the response from the Cloud
+        executor.when(Storage.Objects.List.class, objects);
+
+        project.getBuildersList().add(step);
+        FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
+
+        for (String s : matches) {
+            FilePath result = build.getWorkspace().withSuffix("/" + s);
+            assertTrue(result.exists());
+            assertEquals("contents 1", result.readToString());
+        }
+        for (String s : notMatches) {
+            FilePath result = build.getWorkspace().withSuffix("/" + s);
+            assertFalse("File exists but shouldn't:" + result, result.exists());
+        }
+    }
+
+    @Test
+    public void testBuildWildcards() throws Exception {
+        tryWildcards(
+                "download/log_*.txt",
+                new String[] {
+                    "download/log_1.txt", "download/log_1_.txt", "download/log_.txt", "download/log_ajkl23-d.txt"
+                },
+                new String[] {
+                    "downloa/log_1.txt", "download/log.txt", "download/log_", "download/log_1/a.txt", "download/log_1"
+                });
+    }
+
+    @Test
+    public void testBuildWildcardsOnly() throws Exception {
+        tryWildcards("*", new String[] {"a", "b.txt", "l_a_b_d_f"}, new String[] {"a/b.txt", "/b"});
+    }
+
+    @Test
+    public void testBuildWildcardEnd() throws Exception {
+        tryWildcards("a/*", new String[] {"a/a.txt", "a/b.txt", "a/log"}, new String[] {"a/b/c.txt"});
+    }
+
+    private static final String PROJECT_ID = "foo.com:bar-baz";
+    private static final String CREDENTIALS_ID = "bazinga";
 }

--- a/src/test/java/com/google/jenkins/plugins/storage/ExpiringBucketLifecycleManagerStepTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/ExpiringBucketLifecycleManagerStepTest.java
@@ -38,74 +38,75 @@ import org.mockito.MockitoAnnotations;
 
 /** Tests for {@link ExpiringBucketLifecycleManagerStep} */
 public class ExpiringBucketLifecycleManagerStepTest {
-  @Rule public JenkinsRule jenkins = new JenkinsRule();
-  @Mock private GoogleRobotCredentials credentials;
-  private GoogleCredential credential;
-  @Mock private AbstractGoogleRobotCredentialsDescriptor descriptor;
-  private final MockExecutor executor = new MockExecutor();
-  private NotFoundException notFoundException = new NotFoundException();
-  private static final String PROJECT_ID = "foo.com:project-build";
-  private static final String CREDENTIALS_ID = "creds";
-  private static final String BUCKET_NAME = "test-bucket-43";
-  private static final String BUCKET_URI = "gs://" + BUCKET_NAME;
-  private static final int TTL = 1;
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
 
-  @Before
-  public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
+    @Mock
+    private GoogleRobotCredentials credentials;
 
-    when(descriptor.getDisplayName()).thenReturn("Credentials Name");
+    private GoogleCredential credential;
 
-    when(credentials.getId()).thenReturn(CREDENTIALS_ID);
-    when(credentials.getProjectId()).thenReturn(PROJECT_ID);
-    when(credentials.getDescriptor()).thenReturn(descriptor);
+    @Mock
+    private AbstractGoogleRobotCredentialsDescriptor descriptor;
 
-    if (jenkins.jenkins != null) {
-      SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
+    private final MockExecutor executor = new MockExecutor();
+    private NotFoundException notFoundException = new NotFoundException();
+    private static final String PROJECT_ID = "foo.com:project-build";
+    private static final String CREDENTIALS_ID = "creds";
+    private static final String BUCKET_NAME = "test-bucket-43";
+    private static final String BUCKET_URI = "gs://" + BUCKET_NAME;
+    private static final int TTL = 1;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        when(descriptor.getDisplayName()).thenReturn("Credentials Name");
+
+        when(credentials.getId()).thenReturn(CREDENTIALS_ID);
+        when(credentials.getProjectId()).thenReturn(PROJECT_ID);
+        when(credentials.getDescriptor()).thenReturn(descriptor);
+
+        if (jenkins.jenkins != null) {
+            SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
+        }
+
+        credential = new GoogleCredential();
+        when(credentials.getGoogleCredential(isA(GoogleOAuth2ScopeRequirement.class)))
+                .thenReturn(credential);
+        when(credentials.forRemote(isA(GoogleOAuth2ScopeRequirement.class))).thenReturn(credentials);
     }
 
-    credential = new GoogleCredential();
-    when(credentials.getGoogleCredential(isA(GoogleOAuth2ScopeRequirement.class)))
-        .thenReturn(credential);
-    when(credentials.forRemote(isA(GoogleOAuth2ScopeRequirement.class))).thenReturn(credentials);
-  }
+    private void ConfigurationRoundTripTest(ExpiringBucketLifecycleManagerStep s) throws Exception {
+        ExpiringBucketLifecycleManagerStep after = jenkins.configRoundtrip(s);
+        jenkins.assertEqualBeans(s, after, "bucket,ttl,credentialsId");
+    }
 
-  private void ConfigurationRoundTripTest(ExpiringBucketLifecycleManagerStep s) throws Exception {
-    ExpiringBucketLifecycleManagerStep after = jenkins.configRoundtrip(s);
-    jenkins.assertEqualBeans(s, after, "bucket,ttl,credentialsId");
-  }
+    @Test
+    public void testRoundtrip() throws Exception {
+        ExpiringBucketLifecycleManagerStep step = new ExpiringBucketLifecycleManagerStep(CREDENTIALS_ID, "bucket", 1);
 
-  @Test
-  public void testRoundtrip() throws Exception {
-    ExpiringBucketLifecycleManagerStep step =
-        new ExpiringBucketLifecycleManagerStep(CREDENTIALS_ID, "bucket", 1);
+        ConfigurationRoundTripTest(step);
+    }
 
-    ConfigurationRoundTripTest(step);
-  }
+    @Test
+    public void testBuild() throws Exception {
+        ExpiringBucketLifecycleManagerStep step =
+                new ExpiringBucketLifecycleManagerStep(CREDENTIALS_ID, BUCKET_URI, TTL);
+        FreeStyleProject project = jenkins.createFreeStyleProject("testBuild");
 
-  @Test
-  public void testBuild() throws Exception {
-    ExpiringBucketLifecycleManagerStep step =
-        new ExpiringBucketLifecycleManagerStep(CREDENTIALS_ID, BUCKET_URI, TTL);
-    FreeStyleProject project = jenkins.createFreeStyleProject("testBuild");
+        // Perform is run twice: one from scheduleBuild2, one from step.perform
+        executor.throwWhen(Storage.Buckets.Get.class, notFoundException);
+        executor.passThruWhen(Storage.Buckets.Insert.class, MockUploadModule.checkBucketName(BUCKET_NAME));
 
-    // Perform is run twice: one from scheduleBuild2, one from step.perform
-    executor.throwWhen(Storage.Buckets.Get.class, notFoundException);
-    executor.passThruWhen(
-        Storage.Buckets.Insert.class, MockUploadModule.checkBucketName(BUCKET_NAME));
+        executor.throwWhen(Storage.Buckets.Get.class, notFoundException);
+        executor.passThruWhen(Storage.Buckets.Insert.class, MockUploadModule.checkBucketName(BUCKET_NAME));
 
-    executor.throwWhen(Storage.Buckets.Get.class, notFoundException);
-    executor.passThruWhen(
-        Storage.Buckets.Insert.class, MockUploadModule.checkBucketName(BUCKET_NAME));
+        project.getPublishersList().add(step);
 
-    project.getPublishersList().add(step);
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
 
-    FreeStyleBuild build = project.scheduleBuild2(0).get();
-
-    step.perform(
-        build,
-        build.getWorkspace(),
-        build.getWorkspace().createLauncher(TaskListener.NULL),
-        TaskListener.NULL);
-  }
+        step.perform(
+                build, build.getWorkspace(), build.getWorkspace().createLauncher(TaskListener.NULL), TaskListener.NULL);
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/storage/ExpiringBucketLifecycleManagerTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/ExpiringBucketLifecycleManagerTest.java
@@ -49,253 +49,223 @@ import org.mockito.MockitoAnnotations;
 /** Tests for {@link ExpiringBucketLifecycleManager}. */
 public class ExpiringBucketLifecycleManagerTest {
 
-  @org.junit.Rule public JenkinsRule jenkins = new JenkinsRule();
+    @org.junit.Rule
+    public JenkinsRule jenkins = new JenkinsRule();
 
-  @Mock private GoogleRobotCredentials credentials;
+    @Mock
+    private GoogleRobotCredentials credentials;
 
-  private GoogleCredential credential;
+    private GoogleCredential credential;
 
-  private ExpiringBucketLifecycleManager underTest;
+    private ExpiringBucketLifecycleManager underTest;
 
-  private final MockExecutor executor = new MockExecutor();
-  private ConflictException conflictException;
-  private ForbiddenException forbiddenException;
-  private NotFoundException notFoundException;
+    private final MockExecutor executor = new MockExecutor();
+    private ConflictException conflictException;
+    private ForbiddenException forbiddenException;
+    private NotFoundException notFoundException;
 
-  private Predicate<Storage.Buckets.Update> checkHasOneRuleLifecycle() {
-    return new Predicate<Storage.Buckets.Update>() {
-      @Override
-      public boolean apply(Storage.Buckets.Update operation) {
-        Bucket bucket = (Bucket) operation.getJsonContent();
-        assertNotNull(bucket.getLifecycle());
-        assertNotNull(bucket.getLifecycle().getRule());
-        assertEquals(1, bucket.getLifecycle().getRule().size());
-        return true;
-      }
-    };
-  }
-
-  private static class MockUploadModule extends UploadModule {
-    public MockUploadModule(MockExecutor executor) {
-      this.executor = executor;
+    private Predicate<Storage.Buckets.Update> checkHasOneRuleLifecycle() {
+        return new Predicate<Storage.Buckets.Update>() {
+            @Override
+            public boolean apply(Storage.Buckets.Update operation) {
+                Bucket bucket = (Bucket) operation.getJsonContent();
+                assertNotNull(bucket.getLifecycle());
+                assertNotNull(bucket.getLifecycle().getRule());
+                assertEquals(1, bucket.getLifecycle().getRule().size());
+                return true;
+            }
+        };
     }
 
-    @Override
-    public MockExecutor newExecutor() {
-      return executor;
+    private static class MockUploadModule extends UploadModule {
+        public MockUploadModule(MockExecutor executor) {
+            this.executor = executor;
+        }
+
+        @Override
+        public MockExecutor newExecutor() {
+            return executor;
+        }
+
+        private final MockExecutor executor;
     }
 
-    private final MockExecutor executor;
-  }
-
-  @org.junit.Rule
-  public Verifier verifySawAll =
-      new Verifier() {
+    @org.junit.Rule
+    public Verifier verifySawAll = new Verifier() {
         @Override
         public void verify() {
-          assertTrue(executor.sawAll());
-          assertFalse(executor.sawUnexpected());
+            assertTrue(executor.sawAll());
+            assertFalse(executor.sawUnexpected());
         }
-      };
+    };
 
-  private FreeStyleProject project;
-  private FreeStyleBuild build;
+    private FreeStyleProject project;
+    private FreeStyleBuild build;
 
-  @Before
-  public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
 
-    when(credentials.getId()).thenReturn(CREDENTIALS_ID);
-    when(credentials.getProjectId()).thenReturn(PROJECT_ID);
+        when(credentials.getId()).thenReturn(CREDENTIALS_ID);
+        when(credentials.getProjectId()).thenReturn(PROJECT_ID);
 
-    if (jenkins.jenkins != null) {
-      SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
+        if (jenkins.jenkins != null) {
+            SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
 
-      project = jenkins.createFreeStyleProject("test");
-      project
-          .getPublishersList()
-          .add(
-              // Create a storage plugin with no uploaders to fake things out.
-              new GoogleCloudStorageUploader(CREDENTIALS_ID, null));
-      build = project.scheduleBuild2(0).get();
+            project = jenkins.createFreeStyleProject("test");
+            project.getPublishersList()
+                    .add(
+                            // Create a storage plugin with no uploaders to fake things out.
+                            new GoogleCloudStorageUploader(CREDENTIALS_ID, null));
+            build = project.scheduleBuild2(0).get();
+        }
+
+        credential = new GoogleCredential();
+        when(credentials.getGoogleCredential(isA(GoogleOAuth2ScopeRequirement.class)))
+                .thenReturn(credential);
+
+        // Return ourselves as remotable
+        when(credentials.forRemote(isA(GoogleOAuth2ScopeRequirement.class))).thenReturn(credentials);
+
+        notFoundException = new NotFoundException();
+        conflictException = new ConflictException();
+        forbiddenException = new ForbiddenException();
+
+        underTest = new ExpiringBucketLifecycleManager(
+                BUCKET_URI, new MockUploadModule(executor), TTL, null /* legacy arg */, null /* legacy arg */);
     }
 
-    credential = new GoogleCredential();
-    when(credentials.getGoogleCredential(isA(GoogleOAuth2ScopeRequirement.class)))
-        .thenReturn(credential);
+    @Test
+    @WithoutJenkins
+    public void testGetters() {
+        assertEquals(BUCKET_URI, underTest.getBucket());
+        assertEquals(TTL, underTest.getTtl());
+    }
 
-    // Return ourselves as remotable
-    when(credentials.forRemote(isA(GoogleOAuth2ScopeRequirement.class))).thenReturn(credentials);
+    @Test
+    @WithoutJenkins
+    public void testGettersWithLegacy() {
+        underTest = new ExpiringBucketLifecycleManager(
+                null /* bucket */, new MockUploadModule(executor), null /* ttl */, BUCKET_URI, TTL);
+        assertEquals(BUCKET_URI, underTest.getBucket());
+        assertEquals(TTL, underTest.getTtl());
+    }
 
-    notFoundException = new NotFoundException();
-    conflictException = new ConflictException();
-    forbiddenException = new ForbiddenException();
+    @Test
+    public void testFailingCheckWithAnnotation() throws Exception {
+        final Bucket bucket = new Bucket().setName(BUCKET_NAME);
 
-    underTest =
-        new ExpiringBucketLifecycleManager(
-            BUCKET_URI,
-            new MockUploadModule(executor),
-            TTL,
-            null /* legacy arg */,
-            null /* legacy arg */);
-  }
+        // A get that returns a bucket should trigger a check/decorate/update
+        executor.when(Storage.Buckets.Get.class, bucket);
+        executor.passThruWhen(Storage.Buckets.Update.class, checkHasOneRuleLifecycle());
 
-  @Test
-  @WithoutJenkins
-  public void testGetters() {
-    assertEquals(BUCKET_URI, underTest.getBucket());
-    assertEquals(TTL, underTest.getTtl());
-  }
+        underTest.perform(CREDENTIALS_ID, build, TaskListener.NULL);
+    }
 
-  @Test
-  @WithoutJenkins
-  public void testGettersWithLegacy() {
-    underTest =
-        new ExpiringBucketLifecycleManager(
-            null /* bucket */, new MockUploadModule(executor), null /* ttl */, BUCKET_URI, TTL);
-    assertEquals(BUCKET_URI, underTest.getBucket());
-    assertEquals(TTL, underTest.getTtl());
-  }
-
-  @Test
-  public void testFailingCheckWithAnnotation() throws Exception {
-    final Bucket bucket = new Bucket().setName(BUCKET_NAME);
-
-    // A get that returns a bucket should trigger a check/decorate/update
-    executor.when(Storage.Buckets.Get.class, bucket);
-    executor.passThruWhen(Storage.Buckets.Update.class, checkHasOneRuleLifecycle());
-
-    underTest.perform(CREDENTIALS_ID, build, TaskListener.NULL);
-  }
-
-  @Test
-  public void testBadTTLWithUpdate() throws Exception {
-    final Bucket bucket =
-        new Bucket()
-            .setName(BUCKET_NAME)
-            .setLifecycle(
-                new Bucket.Lifecycle()
-                    .setRule(
-                        ImmutableList.of(
-                            new Rule()
+    @Test
+    public void testBadTTLWithUpdate() throws Exception {
+        final Bucket bucket = new Bucket()
+                .setName(BUCKET_NAME)
+                .setLifecycle(new Bucket.Lifecycle()
+                        .setRule(ImmutableList.of(new Rule()
                                 .setCondition(new Rule.Condition().setAge(BAD_TTL))
                                 .setAction(new Rule.Action().setType("Delete")))));
 
-    // A get that returns a bucket should trigger a check/decorate/update
-    executor.when(Storage.Buckets.Get.class, bucket);
-    executor.passThruWhen(Storage.Buckets.Update.class, checkHasOneRuleLifecycle());
+        // A get that returns a bucket should trigger a check/decorate/update
+        executor.when(Storage.Buckets.Get.class, bucket);
+        executor.passThruWhen(Storage.Buckets.Update.class, checkHasOneRuleLifecycle());
 
-    underTest.perform(CREDENTIALS_ID, build, TaskListener.NULL);
-  }
+        underTest.perform(CREDENTIALS_ID, build, TaskListener.NULL);
+    }
 
-  @Test
-  public void testReplaceComplexLifecycle() throws Exception {
-    final Rule expireGoodTTL =
-        new Rule()
-            .setCondition(new Rule.Condition().setAge(TTL))
-            .setAction(new Rule.Action().setType("Delete"));
-    final Bucket bucket =
-        new Bucket()
-            .setName(BUCKET_NAME)
-            .setLifecycle(
-                new Bucket.Lifecycle()
-                    .setRule(
-                        // Create a list with two good rules, to validate that
-                        // multi-clause rules get thrown out.
-                        ImmutableList.of(expireGoodTTL, expireGoodTTL)));
+    @Test
+    public void testReplaceComplexLifecycle() throws Exception {
+        final Rule expireGoodTTL = new Rule()
+                .setCondition(new Rule.Condition().setAge(TTL))
+                .setAction(new Rule.Action().setType("Delete"));
+        final Bucket bucket = new Bucket()
+                .setName(BUCKET_NAME)
+                .setLifecycle(new Bucket.Lifecycle()
+                        .setRule(
+                                // Create a list with two good rules, to validate that
+                                // multi-clause rules get thrown out.
+                                ImmutableList.of(expireGoodTTL, expireGoodTTL)));
 
-    // A get that returns a bucket should trigger a check/decorate/update
-    executor.when(Storage.Buckets.Get.class, bucket);
-    executor.passThruWhen(Storage.Buckets.Update.class, checkHasOneRuleLifecycle());
+        // A get that returns a bucket should trigger a check/decorate/update
+        executor.when(Storage.Buckets.Get.class, bucket);
+        executor.passThruWhen(Storage.Buckets.Update.class, checkHasOneRuleLifecycle());
 
-    underTest.perform(CREDENTIALS_ID, build, TaskListener.NULL);
-  }
+        underTest.perform(CREDENTIALS_ID, build, TaskListener.NULL);
+    }
 
-  @Test
-  public void testBadAction() throws Exception {
-    final Bucket bucket =
-        new Bucket()
-            .setName(BUCKET_NAME)
-            .setLifecycle(
-                new Bucket.Lifecycle()
-                    .setRule(
-                        ImmutableList.of(
-                            new Rule()
+    @Test
+    public void testBadAction() throws Exception {
+        final Bucket bucket = new Bucket()
+                .setName(BUCKET_NAME)
+                .setLifecycle(new Bucket.Lifecycle()
+                        .setRule(ImmutableList.of(new Rule()
                                 .setCondition(new Rule.Condition().setAge(TTL))
                                 .setAction(new Rule.Action().setType("Unknown")))));
 
-    // A get that returns a bucket should trigger a check/decorate/update
-    executor.when(Storage.Buckets.Get.class, bucket);
-    executor.passThruWhen(Storage.Buckets.Update.class, checkHasOneRuleLifecycle());
+        // A get that returns a bucket should trigger a check/decorate/update
+        executor.when(Storage.Buckets.Get.class, bucket);
+        executor.passThruWhen(Storage.Buckets.Update.class, checkHasOneRuleLifecycle());
 
-    underTest.perform(CREDENTIALS_ID, build, TaskListener.NULL);
-  }
+        underTest.perform(CREDENTIALS_ID, build, TaskListener.NULL);
+    }
 
-  @Test
-  public void testBadCondition() throws Exception {
-    final Bucket bucket =
-        new Bucket()
-            .setName(BUCKET_NAME)
-            .setLifecycle(
-                new Bucket.Lifecycle()
-                    .setRule(
-                        ImmutableList.of(
-                            new Rule()
+    @Test
+    public void testBadCondition() throws Exception {
+        final Bucket bucket = new Bucket()
+                .setName(BUCKET_NAME)
+                .setLifecycle(new Bucket.Lifecycle()
+                        .setRule(ImmutableList.of(new Rule()
                                 .setCondition(new Rule.Condition().setNumNewerVersions(3))
                                 .setAction(new Rule.Action().setType("Delete")))));
 
-    // A get that returns a bucket should trigger a check/decorate/update
-    executor.when(Storage.Buckets.Get.class, bucket);
-    executor.passThruWhen(Storage.Buckets.Update.class, checkHasOneRuleLifecycle());
+        // A get that returns a bucket should trigger a check/decorate/update
+        executor.when(Storage.Buckets.Get.class, bucket);
+        executor.passThruWhen(Storage.Buckets.Update.class, checkHasOneRuleLifecycle());
 
-    underTest.perform(CREDENTIALS_ID, build, TaskListener.NULL);
-  }
+        underTest.perform(CREDENTIALS_ID, build, TaskListener.NULL);
+    }
 
-  @Test
-  public void testBadComplexCondition() throws Exception {
-    final Bucket bucket =
-        new Bucket()
-            .setName(BUCKET_NAME)
-            .setLifecycle(
-                new Bucket.Lifecycle()
-                    .setRule(
-                        ImmutableList.of(
-                            new Rule()
-                                .setCondition(
-                                    new Rule.Condition().setAge(TTL).setNumNewerVersions(3))
+    @Test
+    public void testBadComplexCondition() throws Exception {
+        final Bucket bucket = new Bucket()
+                .setName(BUCKET_NAME)
+                .setLifecycle(new Bucket.Lifecycle()
+                        .setRule(ImmutableList.of(new Rule()
+                                .setCondition(new Rule.Condition().setAge(TTL).setNumNewerVersions(3))
                                 .setAction(new Rule.Action().setType("Delete")))));
 
-    // A get that returns a bucket should trigger a check/decorate/update
-    executor.when(Storage.Buckets.Get.class, bucket);
-    executor.passThruWhen(Storage.Buckets.Update.class, checkHasOneRuleLifecycle());
+        // A get that returns a bucket should trigger a check/decorate/update
+        executor.when(Storage.Buckets.Get.class, bucket);
+        executor.passThruWhen(Storage.Buckets.Update.class, checkHasOneRuleLifecycle());
 
-    underTest.perform(CREDENTIALS_ID, build, TaskListener.NULL);
-  }
+        underTest.perform(CREDENTIALS_ID, build, TaskListener.NULL);
+    }
 
-  @Test
-  public void testPassingCheck() throws Exception {
-    final Bucket bucket =
-        new Bucket()
-            .setName(BUCKET_NAME)
-            .setLifecycle(
-                new Bucket.Lifecycle()
-                    .setRule(
-                        ImmutableList.of(
-                            new Rule()
+    @Test
+    public void testPassingCheck() throws Exception {
+        final Bucket bucket = new Bucket()
+                .setName(BUCKET_NAME)
+                .setLifecycle(new Bucket.Lifecycle()
+                        .setRule(ImmutableList.of(new Rule()
                                 .setCondition(new Rule.Condition().setAge(TTL))
                                 .setAction(new Rule.Action().setType("dElEtE")))));
 
-    // A get that returns a bucket should trigger a check/decorate/update
-    executor.when(Storage.Buckets.Get.class, bucket);
+        // A get that returns a bucket should trigger a check/decorate/update
+        executor.when(Storage.Buckets.Get.class, bucket);
 
-    underTest.perform(CREDENTIALS_ID, build, TaskListener.NULL);
-  }
+        underTest.perform(CREDENTIALS_ID, build, TaskListener.NULL);
+    }
 
-  private static final String PROJECT_ID = "foo.com:bar-baz";
-  private static final String CREDENTIALS_ID = "bazinga";
+    private static final String PROJECT_ID = "foo.com:bar-baz";
+    private static final String CREDENTIALS_ID = "bazinga";
 
-  private static final String BUCKET_NAME = "ma-bucket";
-  private static final String BUCKET_URI = "gs://" + BUCKET_NAME;
-  private static final int TTL = 42;
-  private static final int BAD_TTL = 420;
+    private static final String BUCKET_NAME = "ma-bucket";
+    private static final String BUCKET_URI = "gs://" + BUCKET_NAME;
+    private static final int TTL = 42;
+    private static final int BAD_TTL = 420;
 }

--- a/src/test/java/com/google/jenkins/plugins/storage/HttpHeadersTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/HttpHeadersTest.java
@@ -22,58 +22,58 @@ import org.junit.Test;
 /** Tests for {@link HttpHeaders}. */
 public class HttpHeadersTest {
 
-  @Test
-  public void testGetContentDisposition_ascii() {
-    assertEquals(
-        "attachment; filename=\"myapp.war\"; filename*=UTF-8''myapp.war",
-        HttpHeaders.getContentDisposition("myapp.war", false));
+    @Test
+    public void testGetContentDisposition_ascii() {
+        assertEquals(
+                "attachment; filename=\"myapp.war\"; filename*=UTF-8''myapp.war",
+                HttpHeaders.getContentDisposition("myapp.war", false));
 
-    assertEquals(
-        "attachment; filename=\"contains space.txt\"; " + "filename*=UTF-8''contains%20space.txt",
-        HttpHeaders.getContentDisposition("contains space.txt", false));
-  }
+        assertEquals(
+                "attachment; filename=\"contains space.txt\"; " + "filename*=UTF-8''contains%20space.txt",
+                HttpHeaders.getContentDisposition("contains space.txt", false));
+    }
 
-  @Test
-  public void testGetContentDisposition_asciiInline() {
-    assertEquals(
-        "inline; filename=\"build-log.txt\"; filename*=UTF-8''build-log.txt",
-        HttpHeaders.getContentDisposition("build-log.txt", true));
-  }
+    @Test
+    public void testGetContentDisposition_asciiInline() {
+        assertEquals(
+                "inline; filename=\"build-log.txt\"; filename*=UTF-8''build-log.txt",
+                HttpHeaders.getContentDisposition("build-log.txt", true));
+    }
 
-  @Test
-  public void testGetContentDisposition_unicodeBmp() {
-    assertEquals(
-        "attachment; filename=\"snowman _.txt\"; " + "filename*=UTF-8''snowman%20%E2%98%83.txt",
-        HttpHeaders.getContentDisposition("snowman ☃.txt", false));
-  }
+    @Test
+    public void testGetContentDisposition_unicodeBmp() {
+        assertEquals(
+                "attachment; filename=\"snowman _.txt\"; " + "filename*=UTF-8''snowman%20%E2%98%83.txt",
+                HttpHeaders.getContentDisposition("snowman ☃.txt", false));
+    }
 
-  @Test
-  public void testGetContentDisposition_unicodeNonBmp() {
-    assertEquals(
-        "attachment; filename=\"_.zip\"; filename*=UTF-8''%F0%9D%92%9E.zip",
-        HttpHeaders.getContentDisposition("𝒞.zip", false));
-  }
+    @Test
+    public void testGetContentDisposition_unicodeNonBmp() {
+        assertEquals(
+                "attachment; filename=\"_.zip\"; filename*=UTF-8''%F0%9D%92%9E.zip",
+                HttpHeaders.getContentDisposition("𝒞.zip", false));
+    }
 
-  @Test
-  public void testGetContentDisposition_rfc2616Escapes() {
-    assertEquals(
-        "attachment; filename=\"-\\\\-\\\"-\"; filename*=UTF-8''-%5C-%22-",
-        HttpHeaders.getContentDisposition("-\\-\"-", false));
-  }
+    @Test
+    public void testGetContentDisposition_rfc2616Escapes() {
+        assertEquals(
+                "attachment; filename=\"-\\\\-\\\"-\"; filename*=UTF-8''-%5C-%22-",
+                HttpHeaders.getContentDisposition("-\\-\"-", false));
+    }
 
-  @Test
-  public void testGetContentDisposition_rfc5987IdentitySymbols() {
-    assertEquals(
-        "attachment; filename=\"!#$&+-.^_`|~\"; filename*=UTF-8''!#$&+-.^_`|~",
-        HttpHeaders.getContentDisposition("!#$&+-.^_`|~", false));
-  }
+    @Test
+    public void testGetContentDisposition_rfc5987IdentitySymbols() {
+        assertEquals(
+                "attachment; filename=\"!#$&+-.^_`|~\"; filename*=UTF-8''!#$&+-.^_`|~",
+                HttpHeaders.getContentDisposition("!#$&+-.^_`|~", false));
+    }
 
-  @Test
-  public void testGetContentDisposition_rfc5987PercentEncodedSymbols() {
-    assertEquals(
-        "attachment; filename=\"@%*()=[]{}\\\\:;\\\"'<>,/?\"; "
-            + "filename*=UTF-8''%40%25%2A%28%29%3D%5B%5D%7B%7D%5C%3A%3B%22%27"
-            + "%3C%3E%2C%2F%3F",
-        HttpHeaders.getContentDisposition("@%*()=[]{}\\:;\"'<>,/?", false));
-  }
+    @Test
+    public void testGetContentDisposition_rfc5987PercentEncodedSymbols() {
+        assertEquals(
+                "attachment; filename=\"@%*()=[]{}\\\\:;\\\"'<>,/?\"; "
+                        + "filename*=UTF-8''%40%25%2A%28%29%3D%5B%5D%7B%7D%5C%3A%3B%22%27"
+                        + "%3C%3E%2C%2F%3F",
+                HttpHeaders.getContentDisposition("@%*()=[]{}\\:;\"'<>,/?", false));
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/storage/MockUploadModule.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/MockUploadModule.java
@@ -30,71 +30,71 @@ import java.util.LinkedList;
 
 /** Mock upload module to stub out executor for testing. */
 public class MockUploadModule extends UploadModule {
-  public MockUploadModule(MockExecutor executor) {
-    this(executor, 1 /* retries */);
-  }
-
-  public MockUploadModule(MockExecutor executor, int retries) {
-    this.executor = executor;
-    this.retryCount = retries;
-  }
-
-  @Override
-  public int getInsertRetryCount() {
-    return retryCount;
-  }
-
-  @Override
-  public MockExecutor newExecutor() {
-    return executor;
-  }
-
-  private final MockExecutor executor;
-  private final int retryCount;
-
-  public static Predicate<Storage.Objects.Insert> checkObjectName(final String objectName) {
-    return new Predicate<Storage.Objects.Insert>() {
-      @Override
-      public boolean apply(Storage.Objects.Insert operation) {
-        StorageObject object = (StorageObject) operation.getJsonContent();
-        assertEquals(objectName, object.getName());
-        return true;
-      }
-    };
-  }
-
-  public static Predicate<Storage.Objects.Get> checkGetObject(final String objectName) {
-    return new Predicate<Storage.Objects.Get>() {
-      @Override
-      public boolean apply(Storage.Objects.Get operation) {
-        assertEquals(objectName, operation.getObject());
-        return true;
-      }
-    };
-  }
-
-  public static Predicate<Storage.Buckets.Insert> checkBucketName(final String bucketName) {
-    return new Predicate<Storage.Buckets.Insert>() {
-      @Override
-      public boolean apply(Storage.Buckets.Insert operation) {
-        Bucket bucket = (Bucket) operation.getJsonContent();
-        assertEquals(bucketName, bucket.getName());
-        return true;
-      }
-    };
-  }
-
-  private final LinkedList<InputStream> mediaStreams = new LinkedList<InputStream>();
-
-  public void addNextMedia(InputStream stream) {
-    mediaStreams.add(stream);
-  }
-
-  public InputStream executeMediaAsInputStream(Get getObject) throws IOException {
-    if (mediaStreams.isEmpty()) {
-      return null;
+    public MockUploadModule(MockExecutor executor) {
+        this(executor, 1 /* retries */);
     }
-    return mediaStreams.remove(0);
-  }
+
+    public MockUploadModule(MockExecutor executor, int retries) {
+        this.executor = executor;
+        this.retryCount = retries;
+    }
+
+    @Override
+    public int getInsertRetryCount() {
+        return retryCount;
+    }
+
+    @Override
+    public MockExecutor newExecutor() {
+        return executor;
+    }
+
+    private final MockExecutor executor;
+    private final int retryCount;
+
+    public static Predicate<Storage.Objects.Insert> checkObjectName(final String objectName) {
+        return new Predicate<Storage.Objects.Insert>() {
+            @Override
+            public boolean apply(Storage.Objects.Insert operation) {
+                StorageObject object = (StorageObject) operation.getJsonContent();
+                assertEquals(objectName, object.getName());
+                return true;
+            }
+        };
+    }
+
+    public static Predicate<Storage.Objects.Get> checkGetObject(final String objectName) {
+        return new Predicate<Storage.Objects.Get>() {
+            @Override
+            public boolean apply(Storage.Objects.Get operation) {
+                assertEquals(objectName, operation.getObject());
+                return true;
+            }
+        };
+    }
+
+    public static Predicate<Storage.Buckets.Insert> checkBucketName(final String bucketName) {
+        return new Predicate<Storage.Buckets.Insert>() {
+            @Override
+            public boolean apply(Storage.Buckets.Insert operation) {
+                Bucket bucket = (Bucket) operation.getJsonContent();
+                assertEquals(bucketName, bucket.getName());
+                return true;
+            }
+        };
+    }
+
+    private final LinkedList<InputStream> mediaStreams = new LinkedList<InputStream>();
+
+    public void addNextMedia(InputStream stream) {
+        mediaStreams.add(stream);
+    }
+
+    public InputStream executeMediaAsInputStream(Get getObject) throws IOException {
+        if (mediaStreams.isEmpty()) {
+            return null;
+        }
+        return mediaStreams.remove(0);
+    }
 }
 ;

--- a/src/test/java/com/google/jenkins/plugins/storage/StdoutUploadStepTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/StdoutUploadStepTest.java
@@ -39,86 +39,87 @@ import org.mockito.MockitoAnnotations;
 
 /** Tests for {@link StdoutUploadStep} */
 public class StdoutUploadStepTest {
-  @Rule public JenkinsRule jenkins = new JenkinsRule();
-  @Mock private GoogleRobotCredentials credentials;
-  private GoogleCredential credential;
-  @Mock private AbstractGoogleRobotCredentialsDescriptor descriptor;
-  private final MockExecutor executor = new MockExecutor();
-  private NotFoundException notFoundException = new NotFoundException();
-  private static final String PROJECT_ID = "foo.com:project-build";
-  private static final String CREDENTIALS_ID = "creds";
-  private static final String BUCKET_NAME = "test-bucket-43";
-  private static final String BUCKET_URI = "gs://" + BUCKET_NAME;
-  private static final String LOG_NAME = "build-log.txt";
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
 
-  @Before
-  public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
+    @Mock
+    private GoogleRobotCredentials credentials;
 
-    when(descriptor.getDisplayName()).thenReturn("Credentials Name");
+    private GoogleCredential credential;
 
-    when(credentials.getId()).thenReturn(CREDENTIALS_ID);
-    when(credentials.getProjectId()).thenReturn(PROJECT_ID);
-    when(credentials.getDescriptor()).thenReturn(descriptor);
+    @Mock
+    private AbstractGoogleRobotCredentialsDescriptor descriptor;
 
-    if (jenkins.jenkins != null) {
-      SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
+    private final MockExecutor executor = new MockExecutor();
+    private NotFoundException notFoundException = new NotFoundException();
+    private static final String PROJECT_ID = "foo.com:project-build";
+    private static final String CREDENTIALS_ID = "creds";
+    private static final String BUCKET_NAME = "test-bucket-43";
+    private static final String BUCKET_URI = "gs://" + BUCKET_NAME;
+    private static final String LOG_NAME = "build-log.txt";
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        when(descriptor.getDisplayName()).thenReturn("Credentials Name");
+
+        when(credentials.getId()).thenReturn(CREDENTIALS_ID);
+        when(credentials.getProjectId()).thenReturn(PROJECT_ID);
+        when(credentials.getDescriptor()).thenReturn(descriptor);
+
+        if (jenkins.jenkins != null) {
+            SystemCredentialsProvider.getInstance().getCredentials().add(credentials);
+        }
+
+        credential = new GoogleCredential();
+        when(credentials.getGoogleCredential(isA(GoogleOAuth2ScopeRequirement.class)))
+                .thenReturn(credential);
+        when(credentials.forRemote(isA(GoogleOAuth2ScopeRequirement.class))).thenReturn(credentials);
     }
 
-    credential = new GoogleCredential();
-    when(credentials.getGoogleCredential(isA(GoogleOAuth2ScopeRequirement.class)))
-        .thenReturn(credential);
-    when(credentials.forRemote(isA(GoogleOAuth2ScopeRequirement.class))).thenReturn(credentials);
-  }
+    private void ConfigurationRoundTripTest(StdoutUploadStep s) throws Exception {
+        StdoutUploadStep after = jenkins.configRoundtrip(s);
+        jenkins.assertEqualBeans(s, after, "bucket,logName,pathPrefix,credentialsId");
+    }
 
-  private void ConfigurationRoundTripTest(StdoutUploadStep s) throws Exception {
-    StdoutUploadStep after = jenkins.configRoundtrip(s);
-    jenkins.assertEqualBeans(s, after, "bucket,logName,pathPrefix,credentialsId");
-  }
+    @Test
+    public void testRoundtrip() throws Exception {
+        StdoutUploadStep step = new StdoutUploadStep(CREDENTIALS_ID, "bucket", "logName");
 
-  @Test
-  public void testRoundtrip() throws Exception {
-    StdoutUploadStep step = new StdoutUploadStep(CREDENTIALS_ID, "bucket", "logName");
+        ConfigurationRoundTripTest(step);
 
-    ConfigurationRoundTripTest(step);
+        step.setPathPrefix("prefix");
+        ConfigurationRoundTripTest(step);
 
-    step.setPathPrefix("prefix");
-    ConfigurationRoundTripTest(step);
+        step.setSharedPublicly(true);
+        ConfigurationRoundTripTest(step);
 
-    step.setSharedPublicly(true);
-    ConfigurationRoundTripTest(step);
+        step.setShowInline(true);
+        ConfigurationRoundTripTest(step);
+    }
 
-    step.setShowInline(true);
-    ConfigurationRoundTripTest(step);
-  }
+    @Test
+    public void testBuild() throws Exception {
+        StdoutUploadStep step =
+                new StdoutUploadStep(CREDENTIALS_ID, BUCKET_URI, Optional.of(new MockUploadModule(executor)), LOG_NAME);
 
-  @Test
-  public void testBuild() throws Exception {
-    StdoutUploadStep step =
-        new StdoutUploadStep(
-            CREDENTIALS_ID, BUCKET_URI, Optional.of(new MockUploadModule(executor)), LOG_NAME);
+        FreeStyleProject project = jenkins.createFreeStyleProject("testBuild");
 
-    FreeStyleProject project = jenkins.createFreeStyleProject("testBuild");
+        // Perform is run twice: one from scheduleBuild2, one from step.perform
+        executor.throwWhen(Storage.Buckets.Get.class, notFoundException);
+        executor.passThruWhen(Storage.Buckets.Insert.class, MockUploadModule.checkBucketName(BUCKET_NAME));
+        executor.passThruWhen(Storage.Objects.Insert.class, MockUploadModule.checkObjectName(LOG_NAME));
 
-    // Perform is run twice: one from scheduleBuild2, one from step.perform
-    executor.throwWhen(Storage.Buckets.Get.class, notFoundException);
-    executor.passThruWhen(
-        Storage.Buckets.Insert.class, MockUploadModule.checkBucketName(BUCKET_NAME));
-    executor.passThruWhen(Storage.Objects.Insert.class, MockUploadModule.checkObjectName(LOG_NAME));
+        executor.throwWhen(Storage.Buckets.Get.class, notFoundException);
+        executor.passThruWhen(Storage.Buckets.Insert.class, MockUploadModule.checkBucketName(BUCKET_NAME));
+        executor.passThruWhen(Storage.Objects.Insert.class, MockUploadModule.checkObjectName(LOG_NAME));
 
-    executor.throwWhen(Storage.Buckets.Get.class, notFoundException);
-    executor.passThruWhen(
-        Storage.Buckets.Insert.class, MockUploadModule.checkBucketName(BUCKET_NAME));
-    executor.passThruWhen(Storage.Objects.Insert.class, MockUploadModule.checkObjectName(LOG_NAME));
+        project.getPublishersList().add(step);
 
-    project.getPublishersList().add(step);
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
 
-    FreeStyleBuild build = project.scheduleBuild2(0).get();
-
-    step.perform(
-        build,
-        build.getWorkspace(),
-        build.getWorkspace().createLauncher(TaskListener.NULL),
-        TaskListener.NULL);
-  }
+        step.perform(
+                build, build.getWorkspace(), build.getWorkspace().createLauncher(TaskListener.NULL), TaskListener.NULL);
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/storage/UploadModuleTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/UploadModuleTest.java
@@ -36,52 +36,54 @@ import org.mockito.MockitoAnnotations;
 /** Tests for {@link UploadModule}. */
 public class UploadModuleTest {
 
-  @Rule public JenkinsRule jenkins = new JenkinsRule();
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
 
-  @Rule public ExpectedException thrown = ExpectedException.none();
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
-  @Mock private GoogleRobotCredentials mockGoogleRobotCredentials;
-  private UploadModule underTest;
+    @Mock
+    private GoogleRobotCredentials mockGoogleRobotCredentials;
 
-  GoogleCredential credential = new GoogleCredential();
+    private UploadModule underTest;
 
-  @SuppressWarnings("serial")
-  @Before
-  public void setup() throws Exception {
-    MockitoAnnotations.initMocks(this);
-    underTest = new UploadModule();
+    GoogleCredential credential = new GoogleCredential();
 
-    when(mockGoogleRobotCredentials.getGoogleCredential(isA(GoogleOAuth2ScopeRequirement.class)))
-        .thenReturn(credential);
-  }
+    @SuppressWarnings("serial")
+    @Before
+    public void setup() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        underTest = new UploadModule();
 
-  @Test
-  public void version_space() throws Exception {
-    Storage storage =
-        underTest.getStorageService(mockGoogleRobotCredentials, "0.14-SNAPSHOT (other details)");
-    assertEquals(storage.getApplicationName(), "Jenkins-GCS-Plugin/0.14-SNAPSHOT");
-  }
+        when(mockGoogleRobotCredentials.getGoogleCredential(isA(GoogleOAuth2ScopeRequirement.class)))
+                .thenReturn(credential);
+    }
 
-  @Test
-  public void version_noSpace() throws Exception {
-    Storage storage = underTest.getStorageService(mockGoogleRobotCredentials, "v");
-    assertEquals(storage.getApplicationName(), "Jenkins-GCS-Plugin/v");
-  }
+    @Test
+    public void version_space() throws Exception {
+        Storage storage = underTest.getStorageService(mockGoogleRobotCredentials, "0.14-SNAPSHOT (other details)");
+        assertEquals(storage.getApplicationName(), "Jenkins-GCS-Plugin/0.14-SNAPSHOT");
+    }
 
-  @Test
-  public void version_none() throws Exception {
-    Storage storage = underTest.getStorageService(mockGoogleRobotCredentials, "");
-    assertEquals(storage.getApplicationName(), "Jenkins-GCS-Plugin");
-  }
+    @Test
+    public void version_noSpace() throws Exception {
+        Storage storage = underTest.getStorageService(mockGoogleRobotCredentials, "v");
+        assertEquals(storage.getApplicationName(), "Jenkins-GCS-Plugin/v");
+    }
 
-  @Test
-  public void newUploader_notRightScope()
-      throws GeneralSecurityException, IOException, UploadException {
-    GeneralSecurityException ex = new GeneralSecurityException();
-    when(mockGoogleRobotCredentials.getGoogleCredential(isA(GoogleOAuth2ScopeRequirement.class)))
-        .thenThrow(ex);
-    thrown.expect(IOException.class);
-    thrown.expectMessage(Messages.UploadModule_ExceptionStorageService());
-    underTest.getStorageService(mockGoogleRobotCredentials, "");
-  }
+    @Test
+    public void version_none() throws Exception {
+        Storage storage = underTest.getStorageService(mockGoogleRobotCredentials, "");
+        assertEquals(storage.getApplicationName(), "Jenkins-GCS-Plugin");
+    }
+
+    @Test
+    public void newUploader_notRightScope() throws GeneralSecurityException, IOException, UploadException {
+        GeneralSecurityException ex = new GeneralSecurityException();
+        when(mockGoogleRobotCredentials.getGoogleCredential(isA(GoogleOAuth2ScopeRequirement.class)))
+                .thenThrow(ex);
+        thrown.expect(IOException.class);
+        thrown.expectMessage(Messages.UploadModule_ExceptionStorageService());
+        underTest.getStorageService(mockGoogleRobotCredentials, "");
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/storage/client/ClientFactoryTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/client/ClientFactoryTest.java
@@ -34,31 +34,31 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 /** Tests {@link ClientFactory}. */
 public class ClientFactoryTest {
-  public static final String ACCOUNT_ID = "test-account-id";
-  public static final byte[] PK_BYTES =
-      "{\"client_email\": \"example@example.com\"}".getBytes(StandardCharsets.UTF_8);
+    public static final String ACCOUNT_ID = "test-account-id";
+    public static final byte[] PK_BYTES =
+            "{\"client_email\": \"example@example.com\"}".getBytes(StandardCharsets.UTF_8);
 
-  @Rule public JenkinsRule r = new JenkinsRule();
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
 
-  @Test
-  public void defaultTransport() throws Exception {
-    final String credentialId = "my-google-credential";
+    @Test
+    public void defaultTransport() throws Exception {
+        final String credentialId = "my-google-credential";
 
-    SecretBytes bytes = SecretBytes.fromBytes(PK_BYTES);
-    JsonServiceAccountConfig serviceAccountConfig = new JsonServiceAccountConfig();
-    serviceAccountConfig.setSecretJsonKey(bytes);
-    assertNotNull(serviceAccountConfig.getAccountId());
+        SecretBytes bytes = SecretBytes.fromBytes(PK_BYTES);
+        JsonServiceAccountConfig serviceAccountConfig = new JsonServiceAccountConfig();
+        serviceAccountConfig.setSecretJsonKey(bytes);
+        assertNotNull(serviceAccountConfig.getAccountId());
 
-    GoogleRobotPrivateKeyCredentials c =
-        new GoogleRobotPrivateKeyCredentials(
-            CredentialsScope.GLOBAL, credentialId, ACCOUNT_ID, serviceAccountConfig, null);
-    CredentialsStore store = new SystemCredentialsProvider.ProviderImpl().getStore(r.jenkins);
-    assertNotNull(store);
-    store.addCredentials(Domain.global(), c);
+        GoogleRobotPrivateKeyCredentials c = new GoogleRobotPrivateKeyCredentials(
+                CredentialsScope.GLOBAL, credentialId, ACCOUNT_ID, serviceAccountConfig, null);
+        CredentialsStore store = new SystemCredentialsProvider.ProviderImpl().getStore(r.jenkins);
+        assertNotNull(store);
+        store.addCredentials(Domain.global(), c);
 
-    // Ensure correct exception is thrown
-    assertThrows(
-        GoogleRobotPrivateKeyCredentials.PrivateKeyNotSetException.class,
-        () -> new ClientFactory(r.jenkins, ImmutableList.of(), credentialId, Optional.empty()));
-  }
+        // Ensure correct exception is thrown
+        assertThrows(
+                GoogleRobotPrivateKeyCredentials.PrivateKeyNotSetException.class,
+                () -> new ClientFactory(r.jenkins, ImmutableList.of(), credentialId, Optional.empty()));
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/storage/client/StorageClientTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/client/StorageClientTest.java
@@ -34,147 +34,144 @@ import org.mockito.junit.MockitoJUnitRunner;
 /** Tests {@link StorageClient}. */
 @RunWith(MockitoJUnitRunner.class)
 public class StorageClientTest {
-  private static final String TEST_BUCKET = "test-bucket";
-  private static final String TEST_PATTERN = "test-pattern";
-  private static final InputStreamContent TEST_CONTENT =
-      new InputStreamContent("", Mockito.mock(InputStream.class));
+    private static final String TEST_BUCKET = "test-bucket";
+    private static final String TEST_PATTERN = "test-pattern";
+    private static final InputStreamContent TEST_CONTENT = new InputStreamContent("", Mockito.mock(InputStream.class));
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testInsertObjectErrorWithNullPattern() throws IOException {
-    StorageClient storageClient = setUpObjectInsertClient();
-    storageClient.uploadToBucket(null, TEST_BUCKET, TEST_CONTENT);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testInsertObjectErrorWithNullBucket() throws IOException {
-    StorageClient storageClient = setUpObjectInsertClient();
-    storageClient.uploadToBucket(TEST_PATTERN, null, TEST_CONTENT);
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void testInsertObjectErrorWithNullContent() throws IOException {
-    StorageClient storageClient = setUpObjectInsertClient();
-    storageClient.uploadToBucket(TEST_PATTERN, TEST_BUCKET, null);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testInsertObjectErrorWithEmptyPattern() throws IOException {
-    StorageClient storageClient = setUpObjectInsertClient();
-    storageClient.uploadToBucket("", TEST_BUCKET, TEST_CONTENT);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testInsertObjectErrorWithEmptyBucket() throws IOException {
-    StorageClient storageClient = setUpObjectInsertClient();
-    storageClient.uploadToBucket(TEST_PATTERN, "", TEST_CONTENT);
-  }
-
-  @Test
-  public void testInsertObjectReturnsCorrectly() throws IOException {
-    StorageClient storageClient = setUpObjectInsertClient();
-    Storage.Objects.Insert insertRequest =
-        storageClient.uploadToBucketRequest(TEST_PATTERN, TEST_BUCKET, TEST_CONTENT);
-    assertNotNull(insertRequest);
-    assertEquals(TEST_BUCKET, insertRequest.getBucket());
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testDeleteObjectErrorWithNullPattern() throws IOException {
-    StorageClient storageClient = setUpObjectInsertClient();
-    storageClient.deleteFromBucket(TEST_BUCKET, null);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testDeleteObjectErrorWithNullBucket() throws IOException {
-    StorageClient storageClient = setUpObjectInsertClient();
-    storageClient.deleteFromBucket(null, TEST_PATTERN);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testDeleteObjectErrorWithEmptyPattern() throws IOException {
-    StorageClient storageClient = setUpObjectInsertClient();
-    storageClient.deleteFromBucket(TEST_BUCKET, "");
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testDeleteObjectErrorWithEmptyBucket() throws IOException {
-    StorageClient storageClient = setUpObjectInsertClient();
-    storageClient.deleteFromBucket("", TEST_PATTERN);
-  }
-
-  @Test
-  public void testDeleteObjectReturnsCorrectly() throws IOException {
-    StorageClient storageClient = setUpObjectDeleteClient();
-    Storage.Objects.Delete deleteRequest =
-        storageClient.deleteFromBucketRequest(TEST_BUCKET, TEST_PATTERN);
-    assertNotNull(deleteRequest);
-    assertEquals(TEST_BUCKET, deleteRequest.getBucket());
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testDeleteBucketErrorWithNullBucket() throws IOException {
-    StorageClient storageClient = setUpBucketDeleteClient();
-    storageClient.deleteBucket(null);
-  }
-
-  @Test(expected = IllegalArgumentException.class)
-  public void testDeleteBucketErrorWithEmptyBucket() throws IOException {
-    StorageClient storageClient = setUpBucketDeleteClient();
-    storageClient.deleteBucket("");
-  }
-
-  @Test
-  public void testDeleteBucketReturnsCorrectly() throws IOException {
-    StorageClient storageClient = setUpBucketDeleteClient();
-    Storage.Buckets.Delete deleteRequest = storageClient.deleteBucketRequest(TEST_BUCKET);
-    assertNotNull(deleteRequest);
-    assertEquals(TEST_BUCKET, deleteRequest.getBucket());
-  }
-
-  private static StorageClient setUpObjectClient(
-      Storage.Objects.Insert insertCall, Storage.Objects.Delete deleteCall) throws IOException {
-    Storage storage = Mockito.mock(Storage.class);
-    Storage.Objects objects = Mockito.mock(Storage.Objects.class);
-    when(storage.objects()).thenReturn(objects);
-
-    if (insertCall != null) {
-      when(insertCall.getBucket()).thenReturn(TEST_BUCKET);
-      when(objects.insert(anyString(), ArgumentMatchers.isNull(), any(InputStreamContent.class)))
-          .thenReturn(insertCall);
-      when(insertCall.setName(anyString())).thenReturn(insertCall);
+    @Test(expected = IllegalArgumentException.class)
+    public void testInsertObjectErrorWithNullPattern() throws IOException {
+        StorageClient storageClient = setUpObjectInsertClient();
+        storageClient.uploadToBucket(null, TEST_BUCKET, TEST_CONTENT);
     }
-    if (deleteCall != null) {
-      when(deleteCall.getBucket()).thenReturn(TEST_BUCKET);
-      when(storage.objects().delete(anyString(), anyString())).thenReturn(deleteCall);
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInsertObjectErrorWithNullBucket() throws IOException {
+        StorageClient storageClient = setUpObjectInsertClient();
+        storageClient.uploadToBucket(TEST_PATTERN, null, TEST_CONTENT);
     }
-    return new StorageClient(storage);
-  }
 
-  private static StorageClient setUpObjectInsertClient() throws IOException {
-    Storage.Objects.Insert insertCall = Mockito.mock(Storage.Objects.Insert.class);
-    return setUpObjectClient(insertCall, null);
-  }
-
-  private static StorageClient setUpObjectDeleteClient() throws IOException {
-    Storage.Objects.Delete deleteCall = Mockito.mock(Storage.Objects.Delete.class);
-    return setUpObjectClient(null, deleteCall);
-  }
-
-  private static StorageClient setUpBucketClient(Storage.Buckets.Delete deleteCall)
-      throws IOException {
-    Storage storage = Mockito.mock(Storage.class);
-    Storage.Buckets buckets = Mockito.mock(Storage.Buckets.class);
-    when(storage.buckets()).thenReturn(buckets);
-
-    if (deleteCall != null) {
-      when(deleteCall.getBucket()).thenReturn(TEST_BUCKET);
-      when(storage.buckets().delete(anyString())).thenReturn(deleteCall);
+    @Test(expected = NullPointerException.class)
+    public void testInsertObjectErrorWithNullContent() throws IOException {
+        StorageClient storageClient = setUpObjectInsertClient();
+        storageClient.uploadToBucket(TEST_PATTERN, TEST_BUCKET, null);
     }
-    return new StorageClient(storage);
-  }
 
-  private static StorageClient setUpBucketDeleteClient() throws IOException {
-    Storage.Buckets.Delete deleteCall = Mockito.mock(Storage.Buckets.Delete.class);
-    return setUpBucketClient(deleteCall);
-  }
+    @Test(expected = IllegalArgumentException.class)
+    public void testInsertObjectErrorWithEmptyPattern() throws IOException {
+        StorageClient storageClient = setUpObjectInsertClient();
+        storageClient.uploadToBucket("", TEST_BUCKET, TEST_CONTENT);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInsertObjectErrorWithEmptyBucket() throws IOException {
+        StorageClient storageClient = setUpObjectInsertClient();
+        storageClient.uploadToBucket(TEST_PATTERN, "", TEST_CONTENT);
+    }
+
+    @Test
+    public void testInsertObjectReturnsCorrectly() throws IOException {
+        StorageClient storageClient = setUpObjectInsertClient();
+        Storage.Objects.Insert insertRequest =
+                storageClient.uploadToBucketRequest(TEST_PATTERN, TEST_BUCKET, TEST_CONTENT);
+        assertNotNull(insertRequest);
+        assertEquals(TEST_BUCKET, insertRequest.getBucket());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDeleteObjectErrorWithNullPattern() throws IOException {
+        StorageClient storageClient = setUpObjectInsertClient();
+        storageClient.deleteFromBucket(TEST_BUCKET, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDeleteObjectErrorWithNullBucket() throws IOException {
+        StorageClient storageClient = setUpObjectInsertClient();
+        storageClient.deleteFromBucket(null, TEST_PATTERN);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDeleteObjectErrorWithEmptyPattern() throws IOException {
+        StorageClient storageClient = setUpObjectInsertClient();
+        storageClient.deleteFromBucket(TEST_BUCKET, "");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDeleteObjectErrorWithEmptyBucket() throws IOException {
+        StorageClient storageClient = setUpObjectInsertClient();
+        storageClient.deleteFromBucket("", TEST_PATTERN);
+    }
+
+    @Test
+    public void testDeleteObjectReturnsCorrectly() throws IOException {
+        StorageClient storageClient = setUpObjectDeleteClient();
+        Storage.Objects.Delete deleteRequest = storageClient.deleteFromBucketRequest(TEST_BUCKET, TEST_PATTERN);
+        assertNotNull(deleteRequest);
+        assertEquals(TEST_BUCKET, deleteRequest.getBucket());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDeleteBucketErrorWithNullBucket() throws IOException {
+        StorageClient storageClient = setUpBucketDeleteClient();
+        storageClient.deleteBucket(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDeleteBucketErrorWithEmptyBucket() throws IOException {
+        StorageClient storageClient = setUpBucketDeleteClient();
+        storageClient.deleteBucket("");
+    }
+
+    @Test
+    public void testDeleteBucketReturnsCorrectly() throws IOException {
+        StorageClient storageClient = setUpBucketDeleteClient();
+        Storage.Buckets.Delete deleteRequest = storageClient.deleteBucketRequest(TEST_BUCKET);
+        assertNotNull(deleteRequest);
+        assertEquals(TEST_BUCKET, deleteRequest.getBucket());
+    }
+
+    private static StorageClient setUpObjectClient(Storage.Objects.Insert insertCall, Storage.Objects.Delete deleteCall)
+            throws IOException {
+        Storage storage = Mockito.mock(Storage.class);
+        Storage.Objects objects = Mockito.mock(Storage.Objects.class);
+        when(storage.objects()).thenReturn(objects);
+
+        if (insertCall != null) {
+            when(insertCall.getBucket()).thenReturn(TEST_BUCKET);
+            when(objects.insert(anyString(), ArgumentMatchers.isNull(), any(InputStreamContent.class)))
+                    .thenReturn(insertCall);
+            when(insertCall.setName(anyString())).thenReturn(insertCall);
+        }
+        if (deleteCall != null) {
+            when(deleteCall.getBucket()).thenReturn(TEST_BUCKET);
+            when(storage.objects().delete(anyString(), anyString())).thenReturn(deleteCall);
+        }
+        return new StorageClient(storage);
+    }
+
+    private static StorageClient setUpObjectInsertClient() throws IOException {
+        Storage.Objects.Insert insertCall = Mockito.mock(Storage.Objects.Insert.class);
+        return setUpObjectClient(insertCall, null);
+    }
+
+    private static StorageClient setUpObjectDeleteClient() throws IOException {
+        Storage.Objects.Delete deleteCall = Mockito.mock(Storage.Objects.Delete.class);
+        return setUpObjectClient(null, deleteCall);
+    }
+
+    private static StorageClient setUpBucketClient(Storage.Buckets.Delete deleteCall) throws IOException {
+        Storage storage = Mockito.mock(Storage.class);
+        Storage.Buckets buckets = Mockito.mock(Storage.Buckets.class);
+        when(storage.buckets()).thenReturn(buckets);
+
+        if (deleteCall != null) {
+            when(deleteCall.getBucket()).thenReturn(TEST_BUCKET);
+            when(storage.buckets().delete(anyString())).thenReturn(deleteCall);
+        }
+        return new StorageClient(storage);
+    }
+
+    private static StorageClient setUpBucketDeleteClient() throws IOException {
+        Storage.Buckets.Delete deleteCall = Mockito.mock(Storage.Buckets.Delete.class);
+        return setUpBucketClient(deleteCall);
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/storage/integration/ClassicUploadStepPipelineIT.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/integration/ClassicUploadStepPipelineIT.java
@@ -38,71 +38,68 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 /** Tests the {@link ClassicUploadStep} for use-cases involving the Jenkins Pipeline DSL. */
 public class ClassicUploadStepPipelineIT {
-  private static final Logger LOGGER =
-      Logger.getLogger(ClassicUploadStepPipelineIT.class.getName());
-  @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
-  private static String credentialsId;
-  private static final String pattern = "build_environment.txt";
-  private static String bucket;
-  private static StorageClient storageClient;
-  private static EnvVars envVars;
+    private static final Logger LOGGER = Logger.getLogger(ClassicUploadStepPipelineIT.class.getName());
 
-  @BeforeClass
-  public static void init() throws Exception {
-    LOGGER.info("Initializing ClassicUploadStepPipelineIT");
+    @ClassRule
+    public static JenkinsRule jenkinsRule = new JenkinsRule();
 
-    envVars = initializePipelineITEnvironment(pattern, jenkinsRule);
-    credentialsId = envVars.get("CREDENTIALS_ID");
-    storageClient = new ClientFactory(jenkinsRule.jenkins, credentialsId).storageClient();
-    bucket = formatRandomName("test");
-    envVars.put("BUCKET", bucket);
-  }
+    private static String credentialsId;
+    private static final String pattern = "build_environment.txt";
+    private static String bucket;
+    private static StorageClient storageClient;
+    private static EnvVars envVars;
 
-  @Test
-  public void testClassicUploadStepSuccessful() throws Exception {
-    WorkflowJob testProject =
-        jenkinsRule.createProject(WorkflowJob.class, formatRandomName("test"));
+    @BeforeClass
+    public static void init() throws Exception {
+        LOGGER.info("Initializing ClassicUploadStepPipelineIT");
 
-    testProject.setDefinition(
-        new CpsFlowDefinition(loadResource(getClass(), "classicUploadStepPipeline.groovy"), true));
-    WorkflowRun run = testProject.scheduleBuild2(0).waitForStart();
-    assertNotNull(run);
-    jenkinsRule.assertBuildStatus(Result.SUCCESS, jenkinsRule.waitForCompletion(run));
-    dumpLog(LOGGER, run);
-    storageClient.deleteFromBucket(bucket, pattern);
-  }
+        envVars = initializePipelineITEnvironment(pattern, jenkinsRule);
+        credentialsId = envVars.get("CREDENTIALS_ID");
+        storageClient = new ClientFactory(jenkinsRule.jenkins, credentialsId).storageClient();
+        bucket = formatRandomName("test");
+        envVars.put("BUCKET", bucket);
+    }
 
-  @Test
-  public void testClassicUploadPostStepSuccessful() throws Exception {
-    WorkflowJob testProject =
-        jenkinsRule.createProject(WorkflowJob.class, formatRandomName("test"));
+    @Test
+    public void testClassicUploadStepSuccessful() throws Exception {
+        WorkflowJob testProject = jenkinsRule.createProject(WorkflowJob.class, formatRandomName("test"));
 
-    testProject.setDefinition(
-        new CpsFlowDefinition(
-            loadResource(getClass(), "classicUploadPostStepPipeline.groovy"), true));
-    WorkflowRun run = testProject.scheduleBuild2(0).waitForStart();
-    assertNotNull(run);
-    jenkinsRule.assertBuildStatus(Result.SUCCESS, jenkinsRule.waitForCompletion(run));
-    dumpLog(LOGGER, run);
-    storageClient.deleteFromBucket(bucket, pattern);
-  }
+        testProject.setDefinition(
+                new CpsFlowDefinition(loadResource(getClass(), "classicUploadStepPipeline.groovy"), true));
+        WorkflowRun run = testProject.scheduleBuild2(0).waitForStart();
+        assertNotNull(run);
+        jenkinsRule.assertBuildStatus(Result.SUCCESS, jenkinsRule.waitForCompletion(run));
+        dumpLog(LOGGER, run);
+        storageClient.deleteFromBucket(bucket, pattern);
+    }
 
-  @Test
-  public void testMalformedClassicUploadStepFailure() throws Exception {
-    WorkflowJob testProject =
-        jenkinsRule.createProject(WorkflowJob.class, formatRandomName("test"));
+    @Test
+    public void testClassicUploadPostStepSuccessful() throws Exception {
+        WorkflowJob testProject = jenkinsRule.createProject(WorkflowJob.class, formatRandomName("test"));
 
-    testProject.setDefinition(
-        new CpsFlowDefinition(
-            loadResource(getClass(), "malformedClassicUploadStepPipeline.groovy"), true));
-    WorkflowRun run = testProject.scheduleBuild2(0).waitForStart();
-    assertNotNull(run);
-    jenkinsRule.assertBuildStatus(Result.FAILURE, jenkinsRule.waitForCompletion(run));
-    dumpLog(LOGGER, run);
-  }
+        testProject.setDefinition(
+                new CpsFlowDefinition(loadResource(getClass(), "classicUploadPostStepPipeline.groovy"), true));
+        WorkflowRun run = testProject.scheduleBuild2(0).waitForStart();
+        assertNotNull(run);
+        jenkinsRule.assertBuildStatus(Result.SUCCESS, jenkinsRule.waitForCompletion(run));
+        dumpLog(LOGGER, run);
+        storageClient.deleteFromBucket(bucket, pattern);
+    }
 
-  @AfterClass
-  public static void cleanUp() throws Exception {
-    storageClient.deleteBucket(bucket);
-  }
+    @Test
+    public void testMalformedClassicUploadStepFailure() throws Exception {
+        WorkflowJob testProject = jenkinsRule.createProject(WorkflowJob.class, formatRandomName("test"));
+
+        testProject.setDefinition(
+                new CpsFlowDefinition(loadResource(getClass(), "malformedClassicUploadStepPipeline.groovy"), true));
+        WorkflowRun run = testProject.scheduleBuild2(0).waitForStart();
+        assertNotNull(run);
+        jenkinsRule.assertBuildStatus(Result.FAILURE, jenkinsRule.waitForCompletion(run));
+        dumpLog(LOGGER, run);
+    }
+
+    @AfterClass
+    public static void cleanUp() throws Exception {
+        storageClient.deleteBucket(bucket);
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/storage/integration/ExpiringBucketLifeCycleManagerIT.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/integration/ExpiringBucketLifeCycleManagerIT.java
@@ -36,59 +36,56 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class ExpiringBucketLifeCycleManagerIT {
-  private static final Logger LOGGER =
-      Logger.getLogger(ClassicUploadStepPipelineIT.class.getName());
-  @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
-  private static String credentialsId;
-  // This IT does not need to make explicit use of pattern.
-  private static final String pattern = "test";
-  private static String bucket;
-  private static StorageClient storageClient;
-  private static EnvVars envVars;
+    private static final Logger LOGGER = Logger.getLogger(ClassicUploadStepPipelineIT.class.getName());
 
-  @BeforeClass
-  public static void init() throws Exception {
-    LOGGER.info("Initializing ExpiringBucketLifeCycleManagerIT");
+    @ClassRule
+    public static JenkinsRule jenkinsRule = new JenkinsRule();
 
-    envVars = initializePipelineITEnvironment(pattern, jenkinsRule);
-    credentialsId = envVars.get("CREDENTIALS_ID");
-    storageClient = new ClientFactory(jenkinsRule.jenkins, credentialsId).storageClient();
-    // Create new test bucket to change lifecycle of objects on.
-    bucket = formatRandomName("test");
-    envVars.put("BUCKET", bucket);
-  }
+    private static String credentialsId;
+    // This IT does not need to make explicit use of pattern.
+    private static final String pattern = "test";
+    private static String bucket;
+    private static StorageClient storageClient;
+    private static EnvVars envVars;
 
-  @Test
-  public void testClassicUploadStepSuccessful() throws Exception {
-    WorkflowJob testProject =
-        jenkinsRule.createProject(WorkflowJob.class, formatRandomName("test"));
+    @BeforeClass
+    public static void init() throws Exception {
+        LOGGER.info("Initializing ExpiringBucketLifeCycleManagerIT");
 
-    testProject.setDefinition(
-        new CpsFlowDefinition(
-            loadResource(getClass(), "expiringBucketLifecycleManagerStepPipeline.groovy"), true));
-    WorkflowRun run = testProject.scheduleBuild2(0).waitForStart();
-    assertNotNull(run);
-    jenkinsRule.assertBuildStatus(Result.SUCCESS, jenkinsRule.waitForCompletion(run));
-    dumpLog(LOGGER, run);
-  }
+        envVars = initializePipelineITEnvironment(pattern, jenkinsRule);
+        credentialsId = envVars.get("CREDENTIALS_ID");
+        storageClient = new ClientFactory(jenkinsRule.jenkins, credentialsId).storageClient();
+        // Create new test bucket to change lifecycle of objects on.
+        bucket = formatRandomName("test");
+        envVars.put("BUCKET", bucket);
+    }
 
-  @Test
-  public void testMalformedClassicUploadStepFailure() throws Exception {
-    WorkflowJob testProject =
-        jenkinsRule.createProject(WorkflowJob.class, formatRandomName("test"));
+    @Test
+    public void testClassicUploadStepSuccessful() throws Exception {
+        WorkflowJob testProject = jenkinsRule.createProject(WorkflowJob.class, formatRandomName("test"));
 
-    testProject.setDefinition(
-        new CpsFlowDefinition(
-            loadResource(getClass(), "malformedExpiringBucketLifecycleManagerStepPipeline.groovy"),
-            true));
-    WorkflowRun run = testProject.scheduleBuild2(0).waitForStart();
-    assertNotNull(run);
-    jenkinsRule.assertBuildStatus(Result.FAILURE, jenkinsRule.waitForCompletion(run));
-    dumpLog(LOGGER, run);
-  }
+        testProject.setDefinition(new CpsFlowDefinition(
+                loadResource(getClass(), "expiringBucketLifecycleManagerStepPipeline.groovy"), true));
+        WorkflowRun run = testProject.scheduleBuild2(0).waitForStart();
+        assertNotNull(run);
+        jenkinsRule.assertBuildStatus(Result.SUCCESS, jenkinsRule.waitForCompletion(run));
+        dumpLog(LOGGER, run);
+    }
 
-  @AfterClass
-  public static void cleanUp() throws Exception {
-    storageClient.deleteBucket(bucket);
-  }
+    @Test
+    public void testMalformedClassicUploadStepFailure() throws Exception {
+        WorkflowJob testProject = jenkinsRule.createProject(WorkflowJob.class, formatRandomName("test"));
+
+        testProject.setDefinition(new CpsFlowDefinition(
+                loadResource(getClass(), "malformedExpiringBucketLifecycleManagerStepPipeline.groovy"), true));
+        WorkflowRun run = testProject.scheduleBuild2(0).waitForStart();
+        assertNotNull(run);
+        jenkinsRule.assertBuildStatus(Result.FAILURE, jenkinsRule.waitForCompletion(run));
+        dumpLog(LOGGER, run);
+    }
+
+    @AfterClass
+    public static void cleanUp() throws Exception {
+        storageClient.deleteBucket(bucket);
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/storage/integration/ITUtil.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/integration/ITUtil.java
@@ -40,99 +40,95 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 /** Provides a library of utility functions for integration tests. */
 public class ITUtil {
-  private static String projectId = System.getenv("GOOGLE_PROJECT_ID");
-  private static String bucket = System.getenv("GOOGLE_BUCKET");
+    private static String projectId = System.getenv("GOOGLE_PROJECT_ID");
+    private static String bucket = System.getenv("GOOGLE_BUCKET");
 
-  // DEV MEMO:
-  // In previous versions of google-oauth-plugin, the credentialId was actually the projectId,
-  // making it impossible to have several credentials for
-  // the same project.
-  // This property will allow to override the credentialId to use for the tests.
-  // If it is not set, it will default to the projectId for the tests to match with the former
-  // behavior.
-  private static String credentialId = System.getenv("GOOGLE_CREDENTIAL_ID");
+    // DEV MEMO:
+    // In previous versions of google-oauth-plugin, the credentialId was actually the projectId,
+    // making it impossible to have several credentials for
+    // the same project.
+    // This property will allow to override the credentialId to use for the tests.
+    // If it is not set, it will default to the projectId for the tests to match with the former
+    // behavior.
+    private static String credentialId = System.getenv("GOOGLE_CREDENTIAL_ID");
 
-  /**
-   * Formats a random name using the given prefix.
-   *
-   * @param prefix The prefix to be randomly formatted.
-   * @return The randomly formatted name.
-   */
-  static String formatRandomName(String prefix) {
-    return String.format("%s-%s", prefix, UUID.randomUUID().toString().replace("-", ""));
-  }
-
-  /**
-   * Loads the content of the specified resource.
-   *
-   * @param testClass The test class the resource is being loaded for.
-   * @param name The name of the resource being loaded.
-   * @return The contents of the loaded resource.
-   * @throws IOException If an error occurred during loading.
-   */
-  static String loadResource(Class testClass, String name) throws IOException {
-    return new String(IOUtils.toByteArray(testClass.getResourceAsStream(name)));
-  }
-
-  /**
-   * Dumps the logs from the specified {@link hudson.model.Run}.
-   *
-   * @param logger The {@link java.util.logging.Logger} to be written to.
-   * @param run The {@link hudson.model.Run} from which the logs will be read.
-   * @throws IOException If an error occurred while dumping the logs.
-   */
-  static void dumpLog(Logger logger, Run<?, ?> run) throws IOException {
-    BufferedReader reader = new BufferedReader(run.getLogReader());
-    String line = null;
-    while ((line = reader.readLine()) != null) {
-      logger.info(line);
-    }
-  }
-
-  static String getBucket() {
-    return bucket;
-  }
-
-  /**
-   * Initializes the env variables needed to run pipeline integration tests.
-   *
-   * @param pattern pattern needed to run the integration test. Varies depending on which pipeline
-   *     integration test is being run.
-   * @return Returns handle to EnvVars to change env variables as needed.
-   * @throws Exception If there was an issue initializing or storing credentials.
-   */
-  static EnvVars initializePipelineITEnvironment(String pattern, JenkinsRule jenkinsRule)
-      throws Exception {
-    assertNotNull("GOOGLE_PROJECT_ID env var must be set", projectId);
-    // This bucket is only used for DownloadStepPipelineIT to download objects from.
-    assertNotNull("GOOGLE_BUCKET env var must be set", bucket);
-    String serviceAccountKeyJson = System.getenv("GOOGLE_CREDENTIALS");
-    assertNotNull("GOOGLE_CREDENTIALS env var must be set", serviceAccountKeyJson);
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(pattern));
-
-    if (credentialId == null || credentialId.isEmpty()) {
-      credentialId = projectId;
+    /**
+     * Formats a random name using the given prefix.
+     *
+     * @param prefix The prefix to be randomly formatted.
+     * @return The randomly formatted name.
+     */
+    static String formatRandomName(String prefix) {
+        return String.format("%s-%s", prefix, UUID.randomUUID().toString().replace("-", ""));
     }
 
-    SecretBytes secretBytes =
-        SecretBytes.fromBytes(serviceAccountKeyJson.getBytes(StandardCharsets.UTF_8));
-    JsonServiceAccountConfig sac = new JsonServiceAccountConfig();
-    sac.setSecretJsonKey(secretBytes);
+    /**
+     * Loads the content of the specified resource.
+     *
+     * @param testClass The test class the resource is being loaded for.
+     * @param name The name of the resource being loaded.
+     * @return The contents of the loaded resource.
+     * @throws IOException If an error occurred during loading.
+     */
+    static String loadResource(Class testClass, String name) throws IOException {
+        return new String(IOUtils.toByteArray(testClass.getResourceAsStream(name)));
+    }
 
-    GoogleRobotPrivateKeyCredentials c =
-        new GoogleRobotPrivateKeyCredentials(
-            CredentialsScope.GLOBAL, credentialId, projectId, sac, null);
-    CredentialsStore store =
-        new SystemCredentialsProvider.ProviderImpl().getStore(jenkinsRule.jenkins);
-    assertNotNull(store);
-    store.addCredentials(Domain.global(), c);
+    /**
+     * Dumps the logs from the specified {@link hudson.model.Run}.
+     *
+     * @param logger The {@link java.util.logging.Logger} to be written to.
+     * @param run The {@link hudson.model.Run} from which the logs will be read.
+     * @throws IOException If an error occurred while dumping the logs.
+     */
+    static void dumpLog(Logger logger, Run<?, ?> run) throws IOException {
+        BufferedReader reader = new BufferedReader(run.getLogReader());
+        String line = null;
+        while ((line = reader.readLine()) != null) {
+            logger.info(line);
+        }
+    }
 
-    EnvironmentVariablesNodeProperty prop = new EnvironmentVariablesNodeProperty();
-    EnvVars envVars = prop.getEnvVars();
-    envVars.put("CREDENTIALS_ID", credentialId);
-    envVars.put("BUCKET", bucket);
-    envVars.put("PATTERN", pattern);
-    jenkinsRule.jenkins.getGlobalNodeProperties().add(prop);
-    return envVars;
-  }
+    static String getBucket() {
+        return bucket;
+    }
+
+    /**
+     * Initializes the env variables needed to run pipeline integration tests.
+     *
+     * @param pattern pattern needed to run the integration test. Varies depending on which pipeline
+     *     integration test is being run.
+     * @return Returns handle to EnvVars to change env variables as needed.
+     * @throws Exception If there was an issue initializing or storing credentials.
+     */
+    static EnvVars initializePipelineITEnvironment(String pattern, JenkinsRule jenkinsRule) throws Exception {
+        assertNotNull("GOOGLE_PROJECT_ID env var must be set", projectId);
+        // This bucket is only used for DownloadStepPipelineIT to download objects from.
+        assertNotNull("GOOGLE_BUCKET env var must be set", bucket);
+        String serviceAccountKeyJson = System.getenv("GOOGLE_CREDENTIALS");
+        assertNotNull("GOOGLE_CREDENTIALS env var must be set", serviceAccountKeyJson);
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(pattern));
+
+        if (credentialId == null || credentialId.isEmpty()) {
+            credentialId = projectId;
+        }
+
+        SecretBytes secretBytes = SecretBytes.fromBytes(serviceAccountKeyJson.getBytes(StandardCharsets.UTF_8));
+        JsonServiceAccountConfig sac = new JsonServiceAccountConfig();
+        sac.setSecretJsonKey(secretBytes);
+
+        GoogleRobotPrivateKeyCredentials c =
+                new GoogleRobotPrivateKeyCredentials(CredentialsScope.GLOBAL, credentialId, projectId, sac, null);
+        CredentialsStore store = new SystemCredentialsProvider.ProviderImpl().getStore(jenkinsRule.jenkins);
+        assertNotNull(store);
+        store.addCredentials(Domain.global(), c);
+
+        EnvironmentVariablesNodeProperty prop = new EnvironmentVariablesNodeProperty();
+        EnvVars envVars = prop.getEnvVars();
+        envVars.put("CREDENTIALS_ID", credentialId);
+        envVars.put("BUCKET", bucket);
+        envVars.put("PATTERN", pattern);
+        jenkinsRule.jenkins.getGlobalNodeProperties().add(prop);
+        return envVars;
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/storage/integration/StdoutUploadStepPipelineIT.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/integration/StdoutUploadStepPipelineIT.java
@@ -38,56 +38,55 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 /** Tests the {@link StdoutUploadStep} for use-cases involving the Jenkins Pipeline DSL. */
 public class StdoutUploadStepPipelineIT {
-  private static final Logger LOGGER = Logger.getLogger(StdoutUploadStepPipelineIT.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(StdoutUploadStepPipelineIT.class.getName());
 
-  @ClassRule public static JenkinsRule jenkinsRule = new JenkinsRule();
-  public static String credentialsId;
-  private static final String pattern = "build_log.txt";
-  private static String bucket;
-  private static StorageClient storageClient;
-  private static EnvVars envVars;
+    @ClassRule
+    public static JenkinsRule jenkinsRule = new JenkinsRule();
 
-  @BeforeClass
-  public static void init() throws Exception {
-    LOGGER.info("Initializing StdoutUploadStepPipelineIT");
+    public static String credentialsId;
+    private static final String pattern = "build_log.txt";
+    private static String bucket;
+    private static StorageClient storageClient;
+    private static EnvVars envVars;
 
-    envVars = initializePipelineITEnvironment(pattern, jenkinsRule);
-    credentialsId = envVars.get("CREDENTIALS_ID");
-    storageClient = new ClientFactory(jenkinsRule.jenkins, credentialsId).storageClient();
-    bucket = formatRandomName("test");
-    envVars.put("BUCKET", bucket);
-  }
+    @BeforeClass
+    public static void init() throws Exception {
+        LOGGER.info("Initializing StdoutUploadStepPipelineIT");
 
-  @Test
-  public void testStdoutUploadStepSuccessful() throws Exception {
-    WorkflowJob testProject =
-        jenkinsRule.createProject(WorkflowJob.class, formatRandomName("test"));
+        envVars = initializePipelineITEnvironment(pattern, jenkinsRule);
+        credentialsId = envVars.get("CREDENTIALS_ID");
+        storageClient = new ClientFactory(jenkinsRule.jenkins, credentialsId).storageClient();
+        bucket = formatRandomName("test");
+        envVars.put("BUCKET", bucket);
+    }
 
-    testProject.setDefinition(
-        new CpsFlowDefinition(loadResource(getClass(), "stdoutUploadStepPipeline.groovy"), true));
-    WorkflowRun run = testProject.scheduleBuild2(0).waitForStart();
-    assertNotNull(run);
-    jenkinsRule.assertBuildStatus(Result.SUCCESS, jenkinsRule.waitForCompletion(run));
-    dumpLog(LOGGER, run);
-    storageClient.deleteFromBucket(bucket, pattern);
-  }
+    @Test
+    public void testStdoutUploadStepSuccessful() throws Exception {
+        WorkflowJob testProject = jenkinsRule.createProject(WorkflowJob.class, formatRandomName("test"));
 
-  @Test
-  public void testMalformedStdoutUploadStepFailure() throws Exception {
-    WorkflowJob testProject =
-        jenkinsRule.createProject(WorkflowJob.class, formatRandomName("test"));
+        testProject.setDefinition(
+                new CpsFlowDefinition(loadResource(getClass(), "stdoutUploadStepPipeline.groovy"), true));
+        WorkflowRun run = testProject.scheduleBuild2(0).waitForStart();
+        assertNotNull(run);
+        jenkinsRule.assertBuildStatus(Result.SUCCESS, jenkinsRule.waitForCompletion(run));
+        dumpLog(LOGGER, run);
+        storageClient.deleteFromBucket(bucket, pattern);
+    }
 
-    testProject.setDefinition(
-        new CpsFlowDefinition(
-            loadResource(getClass(), "malformedStdoutUploadStepPipeline.groovy"), true));
-    WorkflowRun run = testProject.scheduleBuild2(0).waitForStart();
-    assertNotNull(run);
-    jenkinsRule.assertBuildStatus(Result.FAILURE, jenkinsRule.waitForCompletion(run));
-    dumpLog(LOGGER, run);
-  }
+    @Test
+    public void testMalformedStdoutUploadStepFailure() throws Exception {
+        WorkflowJob testProject = jenkinsRule.createProject(WorkflowJob.class, formatRandomName("test"));
 
-  @AfterClass
-  public static void cleanUp() throws Exception {
-    storageClient.deleteBucket(bucket);
-  }
+        testProject.setDefinition(
+                new CpsFlowDefinition(loadResource(getClass(), "malformedStdoutUploadStepPipeline.groovy"), true));
+        WorkflowRun run = testProject.scheduleBuild2(0).waitForStart();
+        assertNotNull(run);
+        jenkinsRule.assertBuildStatus(Result.FAILURE, jenkinsRule.waitForCompletion(run));
+        dumpLog(LOGGER, run);
+    }
+
+    @AfterClass
+    public static void cleanUp() throws Exception {
+        storageClient.deleteBucket(bucket);
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/storage/reports/AbstractGcsUploadReportTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/reports/AbstractGcsUploadReportTest.java
@@ -28,36 +28,37 @@ import org.mockito.MockitoAnnotations;
 /** Unit test for {@link AbstractGcsUploadReport}. */
 public class AbstractGcsUploadReportTest {
 
-  @Mock private Actionable parent;
-  private AbstractGcsUploadReport underTest;
+    @Mock
+    private Actionable parent;
 
-  @Before
-  public void setup() {
-    MockitoAnnotations.initMocks(this);
-    underTest =
-        new AbstractGcsUploadReport(parent) {
-          @Override
-          public Set<String> getStorageObjects() {
-            return null;
-          }
+    private AbstractGcsUploadReport underTest;
 
-          @Override
-          public Integer getBuildNumber() {
-            return null;
-          }
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        underTest = new AbstractGcsUploadReport(parent) {
+            @Override
+            public Set<String> getStorageObjects() {
+                return null;
+            }
 
-          @Override
-          public Set<String> getBuckets() {
-            return null;
-          }
+            @Override
+            public Integer getBuildNumber() {
+                return null;
+            }
+
+            @Override
+            public Set<String> getBuckets() {
+                return null;
+            }
         };
-  }
+    }
 
-  @Test
-  public void getters() {
-    assertEquals(parent, underTest.getParent());
-    assertEquals(Messages.AbstractGcsUploadReport_DisplayName(), underTest.getDisplayName());
-    assertNotNull(underTest.getIconFileName());
-    assertNotNull(underTest.getUrlName());
-  }
+    @Test
+    public void getters() {
+        assertEquals(parent, underTest.getParent());
+        assertEquals(Messages.AbstractGcsUploadReport_DisplayName(), underTest.getDisplayName());
+        assertNotNull(underTest.getIconFileName());
+        assertNotNull(underTest.getUrlName());
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/storage/reports/BuildGcsUploadReportTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/reports/BuildGcsUploadReportTest.java
@@ -35,64 +35,64 @@ import org.mockito.MockitoAnnotations;
 /** Unit test for {@link BuildGcsUploadReport}. */
 public class BuildGcsUploadReportTest {
 
-  @Rule public JenkinsRule jenkins = new JenkinsRule();
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
 
-  private AbstractProject<?, ?> project;
-  private AbstractBuild<?, ?> build;
-  private BuildGcsUploadReport underTest;
+    private AbstractProject<?, ?> project;
+    private AbstractBuild<?, ?> build;
+    private BuildGcsUploadReport underTest;
 
-  @Before
-  public void setup() throws Exception {
-    MockitoAnnotations.initMocks(this);
+    @Before
+    public void setup() throws Exception {
+        MockitoAnnotations.initMocks(this);
 
-    project = jenkins.createFreeStyleProject();
-    build = new FreeStyleBuild((FreeStyleProject) project);
-    underTest = new BuildGcsUploadReport(build);
-  }
+        project = jenkins.createFreeStyleProject();
+        build = new FreeStyleBuild((FreeStyleProject) project);
+        underTest = new BuildGcsUploadReport(build);
+    }
 
-  @Test
-  public void getters() {
-    assertEquals(build, underTest.getParent());
-    assertEquals(build.getNumber(), underTest.getBuildNumber().intValue());
-  }
+    @Test
+    public void getters() {
+        assertEquals(build, underTest.getParent());
+        assertEquals(build.getNumber(), underTest.getBuildNumber().intValue());
+    }
 
-  @Test
-  public void addBucket() {
-    assertEquals(0, underTest.getBuckets().size());
-    underTest.addBucket("bucket");
-    assertEquals("bucket", Iterables.getLast(underTest.getBuckets()));
-  }
+    @Test
+    public void addBucket() {
+        assertEquals(0, underTest.getBuckets().size());
+        underTest.addBucket("bucket");
+        assertEquals("bucket", Iterables.getLast(underTest.getBuckets()));
+    }
 
-  @Test
-  public void addUpload() throws Exception {
-    String relativePath = "relative/path";
-    assertEquals(0, underTest.getStorageObjects().size());
-    underTest.addUpload(relativePath, new BucketPath("gs://myBucket/helloworld/18"));
-    assertEquals(
-        "myBucket/helloworld/18/" + relativePath, Iterables.getLast(underTest.getStorageObjects()));
-  }
+    @Test
+    public void addUpload() throws Exception {
+        String relativePath = "relative/path";
+        assertEquals(0, underTest.getStorageObjects().size());
+        underTest.addUpload(relativePath, new BucketPath("gs://myBucket/helloworld/18"));
+        assertEquals("myBucket/helloworld/18/" + relativePath, Iterables.getLast(underTest.getStorageObjects()));
+    }
 
-  @Test
-  public void of() {
-    BuildGcsUploadReport report = BuildGcsUploadReport.of(build);
-    assertNotNull(report);
-  }
+    @Test
+    public void of() {
+        BuildGcsUploadReport report = BuildGcsUploadReport.of(build);
+        assertNotNull(report);
+    }
 
-  @Test
-  public void of_existing() {
-    build.addAction(underTest);
-    assertEquals(underTest, BuildGcsUploadReport.of(build));
-  }
+    @Test
+    public void of_existing() {
+        build.addAction(underTest);
+        assertEquals(underTest, BuildGcsUploadReport.of(build));
+    }
 
-  @Test
-  public void of_project_noLastBuild() {
-    assertNull(BuildGcsUploadReport.of(project));
-  }
+    @Test
+    public void of_project_noLastBuild() {
+        assertNull(BuildGcsUploadReport.of(project));
+    }
 
-  @Test
-  public void of_project_hasLastBuild() throws InterruptedException, ExecutionException {
-    project.scheduleBuild2(0).get();
-    project.getLastBuild().addAction(underTest);
-    assertEquals(underTest, BuildGcsUploadReport.of(project));
-  }
+    @Test
+    public void of_project_hasLastBuild() throws InterruptedException, ExecutionException {
+        project.scheduleBuild2(0).get();
+        project.getLastBuild().addAction(underTest);
+        assertEquals(underTest, BuildGcsUploadReport.of(project));
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/storage/reports/ProjectGcsUploadReportTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/reports/ProjectGcsUploadReportTest.java
@@ -34,48 +34,59 @@ import org.mockito.MockitoAnnotations;
 /** Unit test for {@link ProjectGcsUploadReport}. */
 public class ProjectGcsUploadReportTest {
 
-  @Mock private FreeStyleProject project;
-  @Mock private FreeStyleBuild build;
-  @Mock private FreeStyleBuild noUploadBuild;
-  @Mock private FreeStyleProject noUploadProject;
-  @Mock private BuildGcsUploadReport buildUploadReport;
-  @Mock private DescribableList<Publisher, Descriptor<Publisher>> noUploadPublishers;
+    @Mock
+    private FreeStyleProject project;
 
-  @Before
-  public void setup() throws IOException {
-    MockitoAnnotations.initMocks(this);
-    // set up for a case where the last build did have some uploads.
-    when(project.getLastBuild()).thenReturn(build);
-    when(build.getAction(BuildGcsUploadReport.class)).thenReturn(buildUploadReport);
-    // set up for a case where the last build didn't have any upload.
-    when(noUploadBuild.getProject()).thenReturn(noUploadProject);
-    when(noUploadProject.getLastBuild()).thenReturn(noUploadBuild);
-    when(noUploadProject.getPublishersList()).thenReturn(noUploadPublishers);
-  }
+    @Mock
+    private FreeStyleBuild build;
 
-  @Test
-  public void getters_noUpload() {
-    /* in case there are no upload, test that empty lists are returned */
-    ProjectGcsUploadReport underTest = new ProjectGcsUploadReport(noUploadProject);
-    assertEquals(0, underTest.getBuckets().size());
-    assertEquals(0, underTest.getStorageObjects().size());
-  }
+    @Mock
+    private FreeStyleBuild noUploadBuild;
 
-  @Test
-  public void getters_hasUploads() {
-    /* In case there are uploads, test that the project report delegates to
-     * the report of the last build. */
-    ProjectGcsUploadReport underTest = new ProjectGcsUploadReport(project);
-    Set<String> buckets = ImmutableSet.of("bucket");
-    Set<String> objects = ImmutableSet.of("object1", "object2");
-    int buildNumber = 42;
-    String projectId = "project Id";
-    when(buildUploadReport.getBuckets()).thenReturn(buckets);
-    when(buildUploadReport.getStorageObjects()).thenReturn(objects);
-    when(buildUploadReport.getBuildNumber()).thenReturn(buildNumber);
+    @Mock
+    private FreeStyleProject noUploadProject;
 
-    assertEquals(buckets, underTest.getBuckets());
-    assertEquals(objects, underTest.getStorageObjects());
-    assertEquals(buildNumber, underTest.getBuildNumber().intValue());
-  }
+    @Mock
+    private BuildGcsUploadReport buildUploadReport;
+
+    @Mock
+    private DescribableList<Publisher, Descriptor<Publisher>> noUploadPublishers;
+
+    @Before
+    public void setup() throws IOException {
+        MockitoAnnotations.initMocks(this);
+        // set up for a case where the last build did have some uploads.
+        when(project.getLastBuild()).thenReturn(build);
+        when(build.getAction(BuildGcsUploadReport.class)).thenReturn(buildUploadReport);
+        // set up for a case where the last build didn't have any upload.
+        when(noUploadBuild.getProject()).thenReturn(noUploadProject);
+        when(noUploadProject.getLastBuild()).thenReturn(noUploadBuild);
+        when(noUploadProject.getPublishersList()).thenReturn(noUploadPublishers);
+    }
+
+    @Test
+    public void getters_noUpload() {
+        /* in case there are no upload, test that empty lists are returned */
+        ProjectGcsUploadReport underTest = new ProjectGcsUploadReport(noUploadProject);
+        assertEquals(0, underTest.getBuckets().size());
+        assertEquals(0, underTest.getStorageObjects().size());
+    }
+
+    @Test
+    public void getters_hasUploads() {
+        /* In case there are uploads, test that the project report delegates to
+         * the report of the last build. */
+        ProjectGcsUploadReport underTest = new ProjectGcsUploadReport(project);
+        Set<String> buckets = ImmutableSet.of("bucket");
+        Set<String> objects = ImmutableSet.of("object1", "object2");
+        int buildNumber = 42;
+        String projectId = "project Id";
+        when(buildUploadReport.getBuckets()).thenReturn(buckets);
+        when(buildUploadReport.getStorageObjects()).thenReturn(objects);
+        when(buildUploadReport.getBuildNumber()).thenReturn(buildNumber);
+
+        assertEquals(buckets, underTest.getBuckets());
+        assertEquals(objects, underTest.getStorageObjects());
+        assertEquals(buildNumber, underTest.getBuildNumber().intValue());
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/storage/util/CredentialsUtilTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/util/CredentialsUtilTest.java
@@ -33,50 +33,49 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class CredentialsUtilTest {
-  private static final String TEST_CREDENTIALS_ID = "test-credentials-id";
-  private static final String TEST_INVALID_CREDENTIALS_ID = "test-invalid-credentials-id";
-  @ClassRule public static JenkinsRule r = new JenkinsRule();
+    private static final String TEST_CREDENTIALS_ID = "test-credentials-id";
+    private static final String TEST_INVALID_CREDENTIALS_ID = "test-invalid-credentials-id";
 
-  @Test(expected = AbortException.class)
-  public void testGetRobotCredentialsInvalidCredentialsIdAbortException() throws AbortException {
-    CredentialsUtil.getRobotCredentials(
-        r.jenkins, ImmutableList.<DomainRequirement>of(), TEST_INVALID_CREDENTIALS_ID);
-  }
+    @ClassRule
+    public static JenkinsRule r = new JenkinsRule();
 
-  @Test(expected = GoogleRobotPrivateKeyCredentials.PrivateKeyNotSetException.class)
-  public void testGetGoogleCredentialAbortException() throws Exception {
-    SecretBytes bytes =
-        SecretBytes.fromBytes(
-            "{\"client_email\": \"example@example.com\"}".getBytes(StandardCharsets.UTF_8));
-    JsonServiceAccountConfig serviceAccountConfig = new JsonServiceAccountConfig();
-    serviceAccountConfig.setSecretJsonKey(bytes);
-    assertNotNull(serviceAccountConfig.getAccountId());
-    GoogleRobotCredentials robotCreds =
-        new GoogleRobotPrivateKeyCredentials(
-            TEST_INVALID_CREDENTIALS_ID, serviceAccountConfig, null);
-    CredentialsStore store = new SystemCredentialsProvider.ProviderImpl().getStore(r.jenkins);
-    store.addCredentials(Domain.global(), robotCreds);
-    CredentialsUtil.getGoogleCredential(robotCreds);
-  }
+    @Test(expected = AbortException.class)
+    public void testGetRobotCredentialsInvalidCredentialsIdAbortException() throws AbortException {
+        CredentialsUtil.getRobotCredentials(
+                r.jenkins, ImmutableList.<DomainRequirement>of(), TEST_INVALID_CREDENTIALS_ID);
+    }
 
-  @Test(expected = NullPointerException.class)
-  public void testGetRobotCredentialsWithEmptyItemGroup() throws AbortException {
-    CredentialsUtil.getRobotCredentials(
-        null, ImmutableList.<DomainRequirement>of(), TEST_CREDENTIALS_ID);
-  }
+    @Test(expected = GoogleRobotPrivateKeyCredentials.PrivateKeyNotSetException.class)
+    public void testGetGoogleCredentialAbortException() throws Exception {
+        SecretBytes bytes =
+                SecretBytes.fromBytes("{\"client_email\": \"example@example.com\"}".getBytes(StandardCharsets.UTF_8));
+        JsonServiceAccountConfig serviceAccountConfig = new JsonServiceAccountConfig();
+        serviceAccountConfig.setSecretJsonKey(bytes);
+        assertNotNull(serviceAccountConfig.getAccountId());
+        GoogleRobotCredentials robotCreds =
+                new GoogleRobotPrivateKeyCredentials(TEST_INVALID_CREDENTIALS_ID, serviceAccountConfig, null);
+        CredentialsStore store = new SystemCredentialsProvider.ProviderImpl().getStore(r.jenkins);
+        store.addCredentials(Domain.global(), robotCreds);
+        CredentialsUtil.getGoogleCredential(robotCreds);
+    }
 
-  @Test(expected = NullPointerException.class)
-  public void testGetRobotCredentialsWithEmptyDomainRequirements() throws AbortException {
-    CredentialsUtil.getRobotCredentials(r.jenkins, null, TEST_CREDENTIALS_ID);
-  }
+    @Test(expected = NullPointerException.class)
+    public void testGetRobotCredentialsWithEmptyItemGroup() throws AbortException {
+        CredentialsUtil.getRobotCredentials(null, ImmutableList.<DomainRequirement>of(), TEST_CREDENTIALS_ID);
+    }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testGetRobotCredentialsWithNullCredentialsId() throws AbortException {
-    CredentialsUtil.getRobotCredentials(r.jenkins, ImmutableList.<DomainRequirement>of(), null);
-  }
+    @Test(expected = NullPointerException.class)
+    public void testGetRobotCredentialsWithEmptyDomainRequirements() throws AbortException {
+        CredentialsUtil.getRobotCredentials(r.jenkins, null, TEST_CREDENTIALS_ID);
+    }
 
-  @Test(expected = IllegalArgumentException.class)
-  public void testGetRobotCredentialsWithEmptyCredentialsId() throws AbortException {
-    CredentialsUtil.getRobotCredentials(r.jenkins, ImmutableList.<DomainRequirement>of(), "");
-  }
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetRobotCredentialsWithNullCredentialsId() throws AbortException {
+        CredentialsUtil.getRobotCredentials(r.jenkins, ImmutableList.<DomainRequirement>of(), null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testGetRobotCredentialsWithEmptyCredentialsId() throws AbortException {
+        CredentialsUtil.getRobotCredentials(r.jenkins, ImmutableList.<DomainRequirement>of(), "");
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/storage/util/RetryStorageOperationTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/util/RetryStorageOperationTest.java
@@ -31,210 +31,210 @@ import org.jvnet.hudson.test.WithoutJenkins;
 /** Tests for {@link StorageUtil}. */
 public class RetryStorageOperationTest {
 
-  private final MockExecutor executor = new MockExecutor();
+    private final MockExecutor executor = new MockExecutor();
 
-  // An action that fails the given number of times before succeeding
-  // and then counts the number of successes
-  private class FailOperation implements Operation {
+    // An action that fails the given number of times before succeeding
+    // and then counts the number of successes
+    private class FailOperation implements Operation {
 
-    public int fails;
-    public int succeeded;
+        public int fails;
+        public int succeeded;
 
-    public FailOperation(int fails) {
-      this.fails = fails;
-      this.succeeded = 0;
-    }
-
-    public void act() throws IOException {
-      fails--;
-      if (fails >= 0) {
-        throw new IOException("bad");
-      }
-      succeeded++;
-    }
-  }
-
-  @Test
-  @WithoutJenkins
-  public void retryNoBudgetTest() throws Exception {
-    FailOperation action = new FailOperation(1);
-    try {
-      // Fail immediately if there is no retry budget
-      RetryStorageOperation.performRequestWithRetry(executor, action, 1);
-    } catch (IOException e) {
-      assertEquals(0, action.fails);
-      assertEquals(0, action.succeeded);
-      return;
-    }
-    Assert.fail("Expected exception");
-  }
-
-  @Test
-  @WithoutJenkins
-  public void retrySuccessTest() throws Exception {
-    // Succeed if there is enough budget
-    FailOperation action = new FailOperation(1);
-    RetryStorageOperation.performRequestWithRetry(executor, action, 2);
-    assertEquals(-1, action.fails);
-    assertEquals(1, action.succeeded);
-  }
-
-  @Test
-  @WithoutJenkins
-  public void retryMoreTimesTest() throws Exception {
-    // Correctly count retries for larger numbers
-    FailOperation action = new FailOperation(1);
-    RetryStorageOperation.performRequestWithRetry(executor, action, 10);
-    assertEquals(-1, action.fails);
-    assertEquals(1, action.succeeded);
-  }
-
-  @Test
-  @WithoutJenkins
-  public void retryMoreTimesFailTest() throws Exception {
-    FailOperation action = new FailOperation(9);
-    try {
-      // Fail immediately if there is no retry budget
-      RetryStorageOperation.performRequestWithRetry(executor, action, 5);
-    } catch (IOException e) {
-      assertEquals(4, action.fails);
-      assertEquals(0, action.succeeded);
-      return;
-    }
-    Assert.fail("Expected exception");
-  }
-
-  @Test
-  @WithoutJenkins
-  public void retryLostOfBudgetTest() throws Exception {
-    // Succeed only once even if there is lots of budget
-    FailOperation action = new FailOperation(1);
-    RetryStorageOperation.performRequestWithRetry(executor, action, 10);
-    assertEquals(-1, action.fails);
-    assertEquals(1, action.succeeded);
-  }
-
-  @Test
-  @WithoutJenkins
-  public void retryInterruptedException() throws Exception {
-    // Interrupted exception is handled as well
-    class MixOperation implements Operation {
-
-      int tries;
-      int succeeded = 0;
-
-      MixOperation() {
-        tries = 10;
-      }
-
-      public void act() throws InterruptedException, IOException {
-        if (tries == 0) {
-          succeeded++;
-          return;
+        public FailOperation(int fails) {
+            this.fails = fails;
+            this.succeeded = 0;
         }
-        tries--;
 
-        if (tries % 2 == 1) {
-          throw new IOException("IOExcpetion");
+        public void act() throws IOException {
+            fails--;
+            if (fails >= 0) {
+                throw new IOException("bad");
+            }
+            succeeded++;
         }
-        throw new InterruptedException();
-      }
     }
 
-    MixOperation action = new MixOperation();
-
-    RetryStorageOperation.performRequestWithRetry(executor, action, 200);
-    assertEquals(0, action.tries);
-    assertEquals(1, action.succeeded);
-  }
-
-  private class FailingCredentials implements RepeatOperation<NullPointerException> {
-
-    public int credLength;
-    public int usesLeft;
-    public int stepsLeft;
-    public int failures;
-
-    public FailingCredentials(int credLength, int stepsLeft) {
-      this.credLength = credLength;
-      this.stepsLeft = stepsLeft;
-      usesLeft = 0;
-      failures = 0;
-    }
-
-    public void initCredentials() {
-      usesLeft = credLength;
-    }
-
-    public void act() throws HttpResponseException {
-      assert (stepsLeft > 0);
-
-      if (usesLeft <= 0) {
-        failures++;
-        throw new StubHttpResponseException(STATUS_CODE_UNAUTHORIZED, "No more credentials!");
-      }
-
-      usesLeft--;
-      stepsLeft--;
-    }
-
-    public boolean moreWork() {
-      return stepsLeft > 0;
-    }
-  }
-
-  @Test
-  @WithoutJenkins
-  public void credsRetry() throws Exception {
-    // Perform successful retries
-    FailingCredentials cr = new FailingCredentials(2, 10);
-
-    RetryStorageOperation.performRequestWithReinitCredentials(cr, 1);
-    assertEquals(0, cr.stepsLeft);
-    assertEquals(4, cr.failures); // Needed to refresh 4 times
-  }
-
-  @Test
-  @WithoutJenkins
-  public void credsNoBudget() throws Exception {
-    // No retry budget quits after first failure (here that's after credentials
-    // expire after 2 steps)
-    FailingCredentials cr = new FailingCredentials(2, 10);
-
-    try {
-      RetryStorageOperation.performRequestWithReinitCredentials(cr, 0);
-    } catch (IOException e) {
-      assertEquals(8, cr.stepsLeft);
-      return;
-    }
-    Assert.fail("Expected exception");
-  }
-
-  @Test
-  @WithoutJenkins
-  public void testStuck() throws Exception {
-    // This Operation gets stuck reloading credentials when 5 steps remaining.
-    class StuckCreds extends FailingCredentials {
-
-      public StuckCreds(int credLength, int stepsLeft) {
-        super(credLength, stepsLeft);
-      }
-
-      public void act() throws HttpResponseException {
-        if (stepsLeft <= 5) {
-          usesLeft = 0;
+    @Test
+    @WithoutJenkins
+    public void retryNoBudgetTest() throws Exception {
+        FailOperation action = new FailOperation(1);
+        try {
+            // Fail immediately if there is no retry budget
+            RetryStorageOperation.performRequestWithRetry(executor, action, 1);
+        } catch (IOException e) {
+            assertEquals(0, action.fails);
+            assertEquals(0, action.succeeded);
+            return;
         }
-        super.act();
-      }
+        Assert.fail("Expected exception");
     }
-    StuckCreds cr = new StuckCreds(2, 10);
 
-    try {
-      RetryStorageOperation.performRequestWithReinitCredentials(cr, 2);
-    } catch (IOException e) {
-      assertEquals(5, cr.stepsLeft);
-      return;
+    @Test
+    @WithoutJenkins
+    public void retrySuccessTest() throws Exception {
+        // Succeed if there is enough budget
+        FailOperation action = new FailOperation(1);
+        RetryStorageOperation.performRequestWithRetry(executor, action, 2);
+        assertEquals(-1, action.fails);
+        assertEquals(1, action.succeeded);
     }
-    Assert.fail("Expected exception");
-  }
+
+    @Test
+    @WithoutJenkins
+    public void retryMoreTimesTest() throws Exception {
+        // Correctly count retries for larger numbers
+        FailOperation action = new FailOperation(1);
+        RetryStorageOperation.performRequestWithRetry(executor, action, 10);
+        assertEquals(-1, action.fails);
+        assertEquals(1, action.succeeded);
+    }
+
+    @Test
+    @WithoutJenkins
+    public void retryMoreTimesFailTest() throws Exception {
+        FailOperation action = new FailOperation(9);
+        try {
+            // Fail immediately if there is no retry budget
+            RetryStorageOperation.performRequestWithRetry(executor, action, 5);
+        } catch (IOException e) {
+            assertEquals(4, action.fails);
+            assertEquals(0, action.succeeded);
+            return;
+        }
+        Assert.fail("Expected exception");
+    }
+
+    @Test
+    @WithoutJenkins
+    public void retryLostOfBudgetTest() throws Exception {
+        // Succeed only once even if there is lots of budget
+        FailOperation action = new FailOperation(1);
+        RetryStorageOperation.performRequestWithRetry(executor, action, 10);
+        assertEquals(-1, action.fails);
+        assertEquals(1, action.succeeded);
+    }
+
+    @Test
+    @WithoutJenkins
+    public void retryInterruptedException() throws Exception {
+        // Interrupted exception is handled as well
+        class MixOperation implements Operation {
+
+            int tries;
+            int succeeded = 0;
+
+            MixOperation() {
+                tries = 10;
+            }
+
+            public void act() throws InterruptedException, IOException {
+                if (tries == 0) {
+                    succeeded++;
+                    return;
+                }
+                tries--;
+
+                if (tries % 2 == 1) {
+                    throw new IOException("IOExcpetion");
+                }
+                throw new InterruptedException();
+            }
+        }
+
+        MixOperation action = new MixOperation();
+
+        RetryStorageOperation.performRequestWithRetry(executor, action, 200);
+        assertEquals(0, action.tries);
+        assertEquals(1, action.succeeded);
+    }
+
+    private class FailingCredentials implements RepeatOperation<NullPointerException> {
+
+        public int credLength;
+        public int usesLeft;
+        public int stepsLeft;
+        public int failures;
+
+        public FailingCredentials(int credLength, int stepsLeft) {
+            this.credLength = credLength;
+            this.stepsLeft = stepsLeft;
+            usesLeft = 0;
+            failures = 0;
+        }
+
+        public void initCredentials() {
+            usesLeft = credLength;
+        }
+
+        public void act() throws HttpResponseException {
+            assert (stepsLeft > 0);
+
+            if (usesLeft <= 0) {
+                failures++;
+                throw new StubHttpResponseException(STATUS_CODE_UNAUTHORIZED, "No more credentials!");
+            }
+
+            usesLeft--;
+            stepsLeft--;
+        }
+
+        public boolean moreWork() {
+            return stepsLeft > 0;
+        }
+    }
+
+    @Test
+    @WithoutJenkins
+    public void credsRetry() throws Exception {
+        // Perform successful retries
+        FailingCredentials cr = new FailingCredentials(2, 10);
+
+        RetryStorageOperation.performRequestWithReinitCredentials(cr, 1);
+        assertEquals(0, cr.stepsLeft);
+        assertEquals(4, cr.failures); // Needed to refresh 4 times
+    }
+
+    @Test
+    @WithoutJenkins
+    public void credsNoBudget() throws Exception {
+        // No retry budget quits after first failure (here that's after credentials
+        // expire after 2 steps)
+        FailingCredentials cr = new FailingCredentials(2, 10);
+
+        try {
+            RetryStorageOperation.performRequestWithReinitCredentials(cr, 0);
+        } catch (IOException e) {
+            assertEquals(8, cr.stepsLeft);
+            return;
+        }
+        Assert.fail("Expected exception");
+    }
+
+    @Test
+    @WithoutJenkins
+    public void testStuck() throws Exception {
+        // This Operation gets stuck reloading credentials when 5 steps remaining.
+        class StuckCreds extends FailingCredentials {
+
+            public StuckCreds(int credLength, int stepsLeft) {
+                super(credLength, stepsLeft);
+            }
+
+            public void act() throws HttpResponseException {
+                if (stepsLeft <= 5) {
+                    usesLeft = 0;
+                }
+                super.act();
+            }
+        }
+        StuckCreds cr = new StuckCreds(2, 10);
+
+        try {
+            RetryStorageOperation.performRequestWithReinitCredentials(cr, 2);
+        } catch (IOException e) {
+            assertEquals(5, cr.stepsLeft);
+            return;
+        }
+        Assert.fail("Expected exception");
+    }
 }

--- a/src/test/java/com/google/jenkins/plugins/storage/util/StorageUtilTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/util/StorageUtilTest.java
@@ -31,49 +31,50 @@ import org.jvnet.hudson.test.WithoutJenkins;
 
 /** Tests for {@link StorageUtil}. */
 public class StorageUtilTest {
-  private FilePath workspace;
-  private FilePath nonWorkspace;
+    private FilePath workspace;
+    private FilePath nonWorkspace;
 
-  @Rule public TemporaryFolder tempDir = new TemporaryFolder();
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
 
-  @BeforeClass
-  public static void init() {
-    assumeFalse(SystemUtils.IS_OS_WINDOWS);
-  }
+    @BeforeClass
+    public static void init() {
+        assumeFalse(SystemUtils.IS_OS_WINDOWS);
+    }
 
-  @Before
-  public void setUp() throws Exception {
-    workspace = new FilePath(makeTempDir("workspace"));
-    nonWorkspace = new FilePath(makeTempDir("non-workspace"));
-  }
+    @Before
+    public void setUp() throws Exception {
+        workspace = new FilePath(makeTempDir("workspace"));
+        nonWorkspace = new FilePath(makeTempDir("non-workspace"));
+    }
 
-  @Test
-  @WithoutJenkins
-  public void getRelativePositiveTest() throws Exception {
-    FilePath one = workspace.child(FIRST_NAME);
+    @Test
+    @WithoutJenkins
+    public void getRelativePositiveTest() throws Exception {
+        FilePath one = workspace.child(FIRST_NAME);
 
-    assertEquals(FIRST_NAME, StorageUtil.getRelative(one, workspace));
+        assertEquals(FIRST_NAME, StorageUtil.getRelative(one, workspace));
 
-    FilePath second = one.child(SECOND_NAME);
-    assertEquals(SECOND_NAME, StorageUtil.getRelative(second, one));
-    assertEquals(FIRST_NAME + '/' + SECOND_NAME, StorageUtil.getRelative(second, workspace));
-  }
+        FilePath second = one.child(SECOND_NAME);
+        assertEquals(SECOND_NAME, StorageUtil.getRelative(second, one));
+        assertEquals(FIRST_NAME + '/' + SECOND_NAME, StorageUtil.getRelative(second, workspace));
+    }
 
-  @Test
-  @WithoutJenkins
-  public void getRelativeNegativeTest() throws Exception {
-    FilePath one = workspace.child(FIRST_NAME);
+    @Test
+    @WithoutJenkins
+    public void getRelativeNegativeTest() throws Exception {
+        FilePath one = workspace.child(FIRST_NAME);
 
-    assertEquals(workspace.getRemote(), "/" + StorageUtil.getRelative(workspace, one));
-    assertEquals(nonWorkspace.getRemote(), "/" + StorageUtil.getRelative(nonWorkspace, workspace));
-  }
+        assertEquals(workspace.getRemote(), "/" + StorageUtil.getRelative(workspace, one));
+        assertEquals(nonWorkspace.getRemote(), "/" + StorageUtil.getRelative(nonWorkspace, workspace));
+    }
 
-  private File makeTempDir(String name) throws IOException {
-    File dir = new File(tempDir.getRoot(), name);
-    dir.mkdir();
-    return dir;
-  }
+    private File makeTempDir(String name) throws IOException {
+        File dir = new File(tempDir.getRoot(), name);
+        dir.mkdir();
+        return dir;
+    }
 
-  private static final String FIRST_NAME = "foo";
-  private static final String SECOND_NAME = "bar";
+    private static final String FIRST_NAME = "foo";
+    private static final String SECOND_NAME = "bar";
 }


### PR DESCRIPTION
This repository uses a non-standard (for the Jenkins project) code formatting style and enforcement during the build. This PR switches this repository to use the Jenkins standard project-wide formatting configuration and enforcement with Spotless. The benefit is that it makes it easier for Jenkins developers to go from one project to the next without the cognitive dissonance of switching styles.

### Testing done

Ran `mvn clean verify -DskipTests -DskipITs`.