### PR TITLE
Bump version of google-oauth-plugin and fix tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,6 +102,11 @@
         <artifactId>j2objc-annotations</artifactId>
         <version>2.8</version>
       </dependency>
+      <dependency>
+        <groupId>org.jenkins-ci.plugins</groupId>
+        <artifactId>oauth-credentials</artifactId>
+        <version>0.646.v02b_66dc03d2e</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -239,7 +244,7 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>google-oauth-plugin</artifactId>
       <!-- TODO: Remove this version when it is integrated in Jenkins BOM -->
-      <version>1.318.vb_39c5db_e3041</version>
+      <version>1.328.v6ea_0fb_df5f7b_</version>
       <exclusions>
         <exclusion>
           <groupId>net.sourceforge.findbugs</groupId>

--- a/src/test/java/com/google/jenkins/plugins/storage/ClassicUploadStepTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/ClassicUploadStepTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.when;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.services.storage.Storage;
-import com.google.jenkins.plugins.credentials.oauth.AbstractGoogleRobotCredentialsDescriptor;
 import com.google.jenkins.plugins.credentials.oauth.GoogleOAuth2ScopeRequirement;
 import com.google.jenkins.plugins.credentials.oauth.GoogleRobotCredentials;
 import com.google.jenkins.plugins.util.MockExecutor;
@@ -48,7 +47,6 @@ public class ClassicUploadStepTest {
   @Mock private GoogleRobotCredentials credentials;
 
   private GoogleCredential credential;
-  @Mock private AbstractGoogleRobotCredentialsDescriptor descriptor;
 
   private final MockExecutor executor = new MockExecutor();
 
@@ -58,11 +56,8 @@ public class ClassicUploadStepTest {
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
 
-    when(descriptor.getDisplayName()).thenReturn("Credentials Name");
-
     when(credentials.getId()).thenReturn(CREDENTIALS_ID);
     when(credentials.getProjectId()).thenReturn(PROJECT_ID);
-    when(credentials.getDescriptor()).thenReturn(descriptor);
 
     if (jenkins.jenkins != null) {
       SystemCredentialsProvider.getInstance().getCredentials().add(credentials);

--- a/src/test/java/com/google/jenkins/plugins/storage/DownloadStepTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/DownloadStepTest.java
@@ -28,7 +28,6 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.services.storage.Storage;
 import com.google.api.services.storage.model.Objects;
 import com.google.api.services.storage.model.StorageObject;
-import com.google.jenkins.plugins.credentials.oauth.AbstractGoogleRobotCredentialsDescriptor;
 import com.google.jenkins.plugins.credentials.oauth.GoogleOAuth2ScopeRequirement;
 import com.google.jenkins.plugins.credentials.oauth.GoogleRobotCredentials;
 import com.google.jenkins.plugins.util.MockExecutor;
@@ -63,17 +62,12 @@ public class DownloadStepTest {
 
   private final MockExecutor executor = new MockExecutor();
 
-  @Mock private AbstractGoogleRobotCredentialsDescriptor descriptor;
-
   @Before
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
 
-    when(descriptor.getDisplayName()).thenReturn("Credentials Name");
-
     when(credentials.getId()).thenReturn(CREDENTIALS_ID);
     when(credentials.getProjectId()).thenReturn(PROJECT_ID);
-    when(credentials.getDescriptor()).thenReturn(descriptor);
 
     if (jenkins.jenkins != null) {
       SystemCredentialsProvider.getInstance().getCredentials().add(credentials);

--- a/src/test/java/com/google/jenkins/plugins/storage/ExpiringBucketLifecycleManagerStepTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/ExpiringBucketLifecycleManagerStepTest.java
@@ -21,9 +21,9 @@ import static org.mockito.Mockito.when;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.services.storage.Storage;
-import com.google.jenkins.plugins.credentials.oauth.AbstractGoogleRobotCredentialsDescriptor;
 import com.google.jenkins.plugins.credentials.oauth.GoogleOAuth2ScopeRequirement;
 import com.google.jenkins.plugins.credentials.oauth.GoogleRobotCredentials;
+import com.google.jenkins.plugins.storage.util.GoogleRobotCredentialsDescriptor;
 import com.google.jenkins.plugins.util.MockExecutor;
 import com.google.jenkins.plugins.util.NotFoundException;
 import hudson.model.FreeStyleBuild;
@@ -40,8 +40,11 @@ import org.mockito.MockitoAnnotations;
 public class ExpiringBucketLifecycleManagerStepTest {
   @Rule public JenkinsRule jenkins = new JenkinsRule();
   @Mock private GoogleRobotCredentials credentials;
+
+  @Mock
+  private GoogleRobotCredentialsDescriptor.AbstractGoogleRobotCredentialsTestDescriptor descriptor;
+
   private GoogleCredential credential;
-  @Mock private AbstractGoogleRobotCredentialsDescriptor descriptor;
   private final MockExecutor executor = new MockExecutor();
   private NotFoundException notFoundException = new NotFoundException();
   private static final String PROJECT_ID = "foo.com:project-build";
@@ -55,7 +58,6 @@ public class ExpiringBucketLifecycleManagerStepTest {
     MockitoAnnotations.initMocks(this);
 
     when(descriptor.getDisplayName()).thenReturn("Credentials Name");
-
     when(credentials.getId()).thenReturn(CREDENTIALS_ID);
     when(credentials.getProjectId()).thenReturn(PROJECT_ID);
     when(credentials.getDescriptor()).thenReturn(descriptor);

--- a/src/test/java/com/google/jenkins/plugins/storage/StdoutUploadStepTest.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/StdoutUploadStepTest.java
@@ -21,7 +21,6 @@ import static org.mockito.Mockito.when;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.services.storage.Storage;
-import com.google.jenkins.plugins.credentials.oauth.AbstractGoogleRobotCredentialsDescriptor;
 import com.google.jenkins.plugins.credentials.oauth.GoogleOAuth2ScopeRequirement;
 import com.google.jenkins.plugins.credentials.oauth.GoogleRobotCredentials;
 import com.google.jenkins.plugins.util.MockExecutor;
@@ -42,7 +41,6 @@ public class StdoutUploadStepTest {
   @Rule public JenkinsRule jenkins = new JenkinsRule();
   @Mock private GoogleRobotCredentials credentials;
   private GoogleCredential credential;
-  @Mock private AbstractGoogleRobotCredentialsDescriptor descriptor;
   private final MockExecutor executor = new MockExecutor();
   private NotFoundException notFoundException = new NotFoundException();
   private static final String PROJECT_ID = "foo.com:project-build";
@@ -55,11 +53,8 @@ public class StdoutUploadStepTest {
   public void setUp() throws Exception {
     MockitoAnnotations.initMocks(this);
 
-    when(descriptor.getDisplayName()).thenReturn("Credentials Name");
-
     when(credentials.getId()).thenReturn(CREDENTIALS_ID);
     when(credentials.getProjectId()).thenReturn(PROJECT_ID);
-    when(credentials.getDescriptor()).thenReturn(descriptor);
 
     if (jenkins.jenkins != null) {
       SystemCredentialsProvider.getInstance().getCredentials().add(credentials);

--- a/src/test/java/com/google/jenkins/plugins/storage/util/GoogleRobotCredentialsDescriptor.java
+++ b/src/test/java/com/google/jenkins/plugins/storage/util/GoogleRobotCredentialsDescriptor.java
@@ -1,0 +1,79 @@
+package com.google.jenkins.plugins.storage.util;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.common.base.Strings;
+import com.google.jenkins.plugins.credentials.oauth.GoogleOAuth2ScopeRequirement;
+import com.google.jenkins.plugins.credentials.oauth.GoogleRobotCredentials;
+import com.google.jenkins.plugins.credentials.oauth.GoogleRobotCredentialsModule;
+import com.google.jenkins.plugins.credentials.oauth.Messages;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.util.FormValidation;
+import java.security.GeneralSecurityException;
+import org.kohsuke.stapler.QueryParameter;
+
+/**
+ * Dev Memo: In earlier versions, {@code AbstractGoogleRobotCredentialsDescriptor} was a standalone
+ * abstract class responsible for handling descriptors for Google robot account credential
+ * extensions. Now, {@code AbstractGoogleRobotCredentialsDescriptor} has been restructured and
+ * integrated as a static inner class within {@code GoogleRobotCredentials}.
+ *
+ * <p>This change affects how the descriptor is accessed and used within the codebase. No major
+ * changes in the API usage are expected, but minor adjustments might be necessary in how the class
+ * is instantiated or accessed
+ */
+public class GoogleRobotCredentialsDescriptor extends GoogleRobotCredentials {
+
+  protected GoogleRobotCredentialsDescriptor(
+      CredentialsScope scope,
+      String id,
+      String projectId,
+      String description,
+      GoogleRobotCredentialsModule module) {
+    super(scope, id, projectId, description, module);
+  }
+
+  @Override
+  public Credential getGoogleCredential(GoogleOAuth2ScopeRequirement requirement)
+      throws GeneralSecurityException {
+    return null;
+  }
+
+  @NonNull
+  @Override
+  public String getUsername() {
+    return null;
+  }
+
+  /**
+   * Abstract class for testing Google Robot Credentials Descriptor. This class extends {@link
+   * GoogleRobotCredentials.AbstractGoogleRobotCredentialsDescriptor} and is used for creating test
+   * instances of Google Robot Credentials descriptors.
+   */
+  public abstract static class AbstractGoogleRobotCredentialsTestDescriptor
+      extends GoogleRobotCredentials.AbstractGoogleRobotCredentialsDescriptor {
+    protected AbstractGoogleRobotCredentialsTestDescriptor(
+        Class<? extends GoogleRobotCredentials> clazz, GoogleRobotCredentialsModule module) {
+      super(clazz);
+      this.module = checkNotNull(module);
+    }
+
+    /** The module to use for instantiating depended upon resources */
+    public GoogleRobotCredentialsModule getModule() {
+      return module;
+    }
+
+    private final GoogleRobotCredentialsModule module;
+
+    /** Validate project-id entries */
+    public FormValidation doCheckProjectId(@QueryParameter String projectId) {
+      if (!Strings.isNullOrEmpty(projectId)) {
+        return FormValidation.ok();
+      } else {
+        return FormValidation.error(Messages.GoogleRobotMetadataCredentials_ProjectIDError());
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces updates to the tests in response to the recent changes made in the google-oauth-plugin (PR [#201](https://github.com/jenkinsci/google-oauth-plugin/pull/201)). 
The key change involves the restructuring of `AbstractGoogleRobotCredentialsDescriptor`, which has now been integrated as a static inner class within `GoogleRobotCredentials`.
<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
