### PR TITLE
Set the cloud-platform access scope

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/storage/StorageScopeRequirement.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/StorageScopeRequirement.java
@@ -20,11 +20,14 @@ import com.google.common.collect.ImmutableList;
 import com.google.jenkins.plugins.credentials.oauth.GoogleOAuth2ScopeRequirement;
 import java.util.Collection;
 
-/** The required OAuth2 scopes for managing Google Cloud Storage buckets and objects. */
+/**
+ * The required OAuth2 scopes for managing Google Cloud Storage buckets and
+ * objects.
+ */
 public class StorageScopeRequirement extends GoogleOAuth2ScopeRequirement {
     /** {@inheritDoc} */
     @Override
     public Collection<String> getScopes() {
-        return ImmutableList.of(StorageScopes.DEVSTORAGE_FULL_CONTROL);
+        return ImmutableList.of(StorageScopes.CLOUD_PLATFORM);
     }
 }


### PR DESCRIPTION
I would like to suggest the use of CLOUD_PLATFORM scope instead of the DEVSTORAGE_FULL_CONTROL scope.
I am facing a problem with Jenkins deployed in GKE and using Workload identity as the authentication method for Jenkins agents where I cannot use this plugin because of the scope requirement.

<img width="418" alt="Screenshot 2023-12-22 at 7 04 54 p m" src="https://github.com/jenkinsci/google-storage-plugin/assets/89871668/542df56f-4540-47b1-bd57-30d448803b92">


The suggestion is also motivated by this lines:

"There are many access scopes available to choose from, but a best practice is to set the cloud-platform access scope, which is an OAuth scope for Google Cloud services, and then control the service account's access by granting it IAM roles."

Found in [Google documentation](https://cloud.google.com/compute/docs/access/service-accounts#scopes_best_practice)

This fixes #231 
### Testing done

I test the change manually and it seems to fix the problem described.
 
<img width="296" alt="Screenshot 2023-12-22 at 7 10 07 p m" src="https://github.com/jenkinsci/google-storage-plugin/assets/89871668/0c39c2c0-cf45-4efe-8eca-af670fc71aac">
