### PR TITLE
Bump `google-http-client-gson`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
       <dependency>
         <groupId>com.google.http-client</groupId>
         <artifactId>google-http-client-gson</artifactId>
-        <version>1.43.1</version>
+        <version>1.43.3</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Routine dependency bump. The new versions is consistent with other Google plugins in the Update Center. The only testing I have done is the CI build.