### PR TITLE
Ensure include FilePath in Windows has normalized separators

### DIFF
--- a/src/main/java/com/google/jenkins/plugins/storage/util/StorageUtil.java
+++ b/src/main/java/com/google/jenkins/plugins/storage/util/StorageUtil.java
@@ -41,10 +41,12 @@ public class StorageUtil {
      */
     public static String getRelative(FilePath include, FilePath workspace) throws UploadException {
         LinkedList<String> segments = new LinkedList<String>();
+        String includePath = include.getRemote();
+        include = new FilePath(include.getChannel(), includePath.replace("\\", "/"));
         while (!include.equals(workspace)) {
             segments.push(include.getName());
             include = include.getParent();
-            if (Strings.isNullOrEmpty(include.getName())) {
+            if (include == null || Strings.isNullOrEmpty(include.getName())) {
                 // When we reach "/" we're done either way.
                 break;
             }


### PR DESCRIPTION
The issue and explanation is laid out in https://github.com/jenkinsci/google-storage-plugin/issues/305#issuecomment-2186516763
I'm creating this PR in hopes it helps anyone else facing the same issue.

I understand that the code might might not be fully production ready, or that a better approach might exist, I'd be happy to work towards a better solution after some guidance :)

Closes https://github.com/jenkinsci/google-storage-plugin/issues/305

### Testing done
This was tested by running Jenkins with the compiled plugin and validating that a file was in fact uploaded. Before this change, we got a stacktrace when running in Windows. After, we have a file in our bucket. I can provide screenshots of the before/after if needed after some redaction

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
